### PR TITLE
Add basic runtime support

### DIFF
--- a/default.mspec
+++ b/default.mspec
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require "ruby-next/runtime"

--- a/lib/ruby-next/runtime.rb
+++ b/lib/ruby-next/runtime.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+require "ruby-next"
+
+module RubyNext
+  # Module responsible for runtime transformations
+  module Runtime
+    class << self
+      attr_reader :load_dirs
+
+      def load(path, wrap: false)
+        contents = File.read(path)
+        # inject `using RubyNext`
+        contents.sub!(/^(\s*[^#\s].*)/, 'using RubyNext;\1')
+        # TODO: handle wrap
+        TOPLEVEL_BINDING.eval(contents, path)
+        true
+      end
+
+      def transformable?(path)
+        load_dirs.any? { |dir| path.start_with?(dir) }
+      end
+
+      def feature_path(path)
+        if File.file?(relative = File.expand_path(path))
+          path = relative
+        end
+        path = "#{path}.rb" if File.extname(path).empty?
+        return if File.extname(path) != ".rb"
+
+        unless Pathname.new(path).absolute?
+          loadpath = $LOAD_PATH.find do |lp|
+            File.file?(File.join(lp, path))
+          end
+
+          return if loadpath.nil?
+
+          path = File.join(loadpath, path)
+        end
+
+        return unless transformable?(path)
+
+        path
+      end
+
+      private
+
+      attr_writer :load_dirs
+    end
+
+    self.load_dirs = %w[app lib spec test].map { |path| File.join(Dir.pwd, path) }
+    load_dirs << Dir.pwd
+  end
+end
+
+# Patch Kernel to hijack require/require_relative/load
+module Kernel
+  module_function # rubocop:disable Style/ModuleFunction
+
+  alias_method :require_without_ruby_next, :require
+  def require(path)
+    realpath = RubyNext::Runtime.feature_path(path)
+    return require_without_ruby_next(path) unless realpath
+
+    return false if $LOADED_FEATURES.include?(realpath)
+
+    RubyNext::Runtime.load(realpath)
+
+    $LOADED_FEATURES << realpath
+    true
+  rescue => e
+    warn "RubyNext failed to require '#{path}': #{e.message}"
+    require_without_ruby_next(path)
+  end
+
+  alias_method :require_relative_without_ruby_next, :require_relative
+  def require_relative(path)
+    from = caller_locations(1..1).first.absolute_path
+    realpath = File.absolute_path(
+      File.join(
+        File.dirname(File.absolute_path(from)),
+        path
+      )
+    )
+    require(realpath)
+  rescue => e
+    warn "RubyNext failed to require relative '#{path}' from #{from}: #{e.message}"
+    require_relative_without_ruby_next(path)
+  end
+
+  alias_method :load_without_ruby_next, :load
+  def load(path, wrap = false)
+    realpath = RubyNext::Runtime.feature_path(path)
+
+    return load_without_ruby_next(path, wrap) unless realpath
+
+    RubyNext::Runtime.load(realpath, wrap: wrap)
+  rescue => e
+    warn "RubyNext failed to load '#{path}': #{e.message}"
+    load_without_ruby_next(path)
+  end
+end

--- a/lib/uby-next.rb
+++ b/lib/uby-next.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "ruby-next/runtime"

--- a/spec/core/kernel/shared/then.rb
+++ b/spec/core/kernel/shared/then.rb
@@ -1,7 +1,5 @@
 # source: https://github.com/ruby/spec/blob/master/core/kernel/shared/then.rb 
 
-using RubyNext
-
 # NOTE: `send(@method)` was changed to the direct `then` call to make it work in JRuby.
 #       See https://github.com/jruby/jruby/issues/5945
 describe :kernel_then, shared: true do

--- a/spec/core/kernel/then_spec.rb
+++ b/spec/core/kernel/then_spec.rb
@@ -3,8 +3,6 @@
 require_relative '../../spec_helper'
 require_relative 'shared/then'
 
-using RubyNext
-
 ruby_version_is "2.6" do
   describe "Kernel#then" do
     it_behaves_like :kernel_then, :then

--- a/spec/core/proc/compose_spec.rb
+++ b/spec/core/proc/compose_spec.rb
@@ -3,8 +3,6 @@
 require_relative '../../spec_helper'
 require_relative 'shared/compose'
 
-using RubyNext
-
 ruby_version_is "2.6" do
   describe "Proc#<<" do
     it "returns a Proc that is the composition of self and the passed Proc" do

--- a/spec/core/proc/shared/compose.rb
+++ b/spec/core/proc/shared/compose.rb
@@ -1,7 +1,5 @@
 # source: https://github.com/ruby/spec/blob/master/core/proc/shared/compose.rb
 
-using RubyNext
-
 describe :proc_compose, shared: true do
   # Skip JRuby 'cause it doesn't support refinements in `send`
   # See https://github.com/jruby/jruby/issues/5945

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("../../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-
-require "ruby-next"
-
 # override ruby_version_is method to always run tests
 def ruby_version_is(*)
   yield


### PR DESCRIPTION
### What is the purpose of this pull request?

Investigate runtime capabilities (or how to hack Ruby file loading system 😉).

### What changes did you make? (overview)

- [x] Patched Kernel to hijack require/require_relative/load
- [x] Inject `using RubyNext` to application/library related files
- [x] Removed explicit `using RubyNext` from specs

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
