### PR TITLE
Add numbered parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add numbered parameters. ([@palkan][])
+
 - Add arguments forwarding. ([@palkan][])
 
 - Add `Enumerable#filter_map`. ([@palkan][])

--- a/SUPPORTED_FEATURES.md
+++ b/SUPPORTED_FEATURES.md
@@ -42,8 +42,6 @@
 
 ### 2.7
 
-- (TODO) Startless ranges (`..1` or `...1`) ([#14799](https://bugs.ruby-lang.org/issues/14799))
-
 - (Partial support, work in progress ⚒) Pattern matching (`case ... in ... end`)
 
 Hash pattern matching (`#deconstruct_keys`) is still in progress. Other features have been implemented.
@@ -52,4 +50,6 @@ Hash pattern matching (`#deconstruct_keys`) is still in progress. Other features
 
 - Arguments forwarding (`def a(...) b(...) end`) ([#16253](https://bugs.ruby-lang.org/issues/13581))
 
-- (TODO) Numbered parameters (`block { _1 }`)
+- Numbered parameters (`block { _1 }`)
+
+- (TODO) Startless ranges (`..1` or `...1`) ([#14799](https://bugs.ruby-lang.org/issues/14799))

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -93,5 +93,8 @@ module RubyNext
 
     require "ruby-next/language/rewriters/args_forward"
     rewriters << Rewriters::ArgsForward
+
+    require "ruby-next/language/rewriters/numbered_params"
+    rewriters << Rewriters::NumberedParams
   end
 end

--- a/lib/ruby-next/language/rewriters/base.rb
+++ b/lib/ruby-next/language/rewriters/base.rb
@@ -12,7 +12,7 @@ module RubyNext
             eval_mid = Kernel.respond_to?(:eval_without_ruby_next) ? :eval_without_ruby_next : :eval
             Kernel.send eval_mid, self::SYNTAX_PROBE
             false
-          rescue SyntaxError
+          rescue SyntaxError, NameError
             true
           ensure
             $VERBOSE = save_verbose

--- a/lib/ruby-next/language/rewriters/numbered_params.rb
+++ b/lib/ruby-next/language/rewriters/numbered_params.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+using RubyNext
+
+module RubyNext
+  module Language
+    module Rewriters
+      class NumberedParams < Base
+        SYNTAX_PROBE = "proc { _1 }.call(1)"
+        MIN_SUPPORTED_VERSION = Gem::Version.new("2.7.0")
+
+        def on_numblock(node)
+          context.track! self
+
+          proc_or_lambda, num, *rest = *node.children
+
+          node.updated(
+            :block,
+            [
+              proc_or_lambda,
+              proc_args(num),
+              *rest
+            ]
+          )
+        end
+
+        private
+
+        def proc_args(n)
+          return s(:args, s(:procarg0, :_1)) if n == 1
+
+          (1..n).map do |numero|
+            s(:arg, :"_#{numero}")
+          end.then do |args|
+            s(:args, *args)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/language/numbered_params_spec.rb
+++ b/spec/language/numbered_params_spec.rb
@@ -1,0 +1,31 @@
+# source: https://github.com/ruby/ruby/blob/master/test/ruby/test_syntax.rb#L1418
+
+require_relative '../test_unit_to_mspec'
+
+using TestUnitToMspec
+
+describe "numbered parameters: -> { _1 + _2 }" do
+  it "block" do
+    assert_equal(3, eval('[1,2].yield_self {_1+_2}'))
+  end
+  
+  it "block + interpolation" do 
+    assert_equal("12", eval('[1,2].yield_self {"#{_1}#{_2}"}'))
+  end
+
+  it "block one param" do 
+    assert_equal([1, 2], eval('[1,2].yield_self {_1}'))
+  end
+
+  it "lambda" do 
+    assert_equal(3, eval('->{_1+_2}.call(1,2)'))
+  end
+
+  it "composed lambdas" do 
+    assert_equal(4, eval('->(a=->{_1}){a}.call.call(4)'))
+  end
+
+  it "composed lambdas 2" do 
+    assert_equal(5, eval('-> a: ->{_1} {a}.call.call(5)'))
+  end
+end


### PR DESCRIPTION
### What is the purpose of this pull request?

Make `-> { _1 + _2 }.call(1, 2)` work in Ruby <2.7.

### What changes did you make? (overview)

Add `Rewriters::NumberedParams` which adds the `args` definition to procs/lambdas:

```ruby
-> { _1 + _2 }.call(1, 2)

=>

->(_1, _2) { _1 + _2 }.call(1, 2)
```

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md
