### PR TITLE
Add in modifier support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## master
 
+- Support in modifier. ([@palkan][])
+
+```ruby
+{a:1, b: 2} in {a:, **}
+p a #=> 1
+```
+
 ## 0.1.0 (2019-11-18)
 
 - Support hash pattern in array and vice versa. ([@palkan][])

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gem "pry-byebug", platform: :mri
 eval_gemfile "gemfiles/rubocop.gemfile"
 
 source "https://rubygems.pkg.github.com/ruby-next" do
-  gem "parser", "2.6.3.102"
+  gem "parser", "2.6.3.105"
 end

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Then, add to your Gemfile:
 
 ```ruby
 source "https://rubygems.pkg.github.com/ruby-next" do
-  gem "parser", "2.6.3.102"
+  gem "parser", "2.6.3.103"
 end
 
 gem "unparser", "~> 0.4.5"

--- a/SUPPORTED_FEATURES.md
+++ b/SUPPORTED_FEATURES.md
@@ -42,7 +42,9 @@
 
 ### 2.7
 
-- Pattern matching (`case ... in ... end`)
+- Pattern matching (`case ... in ... end`) ([#14912](https://bugs.ruby-lang.org/issues/14912))
+
+- One line pattern matching (`1 in a`) ([#15865](https://bugs.ruby-lang.org/issues/15865))
 
 - **REVERTED IN RUBY ([#16275](https://bugs.ruby-lang.org/issues/16275))** Method reference operator (`Module.:method`) ([#12125](https://bugs.ruby-lang.org/issues/12125), [#13581](https://bugs.ruby-lang.org/issues/13581))
 

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "parser", "~> 2.6.3.102"
+gem "parser", "~> 2.6.3.105"
 gem "unparser", "~> 0.4.5"
 
 require "set"

--- a/spec/language/pattern_matching_spec.rb
+++ b/spec/language/pattern_matching_spec.rb
@@ -1186,11 +1186,17 @@ END
 
   ################################################################
 
-#   it "modifier_in" do
-#     assert_equal true, (1 in a)
-#     assert_equal 1, a
-#     assert_valid_syntax "p(({} in a:), a:\n 1)"
-#   end
+  it "modifier_in" do
+    assert_equal true, (1 in a)
+    assert_equal 1, a
+    assert_valid_syntax "p(({} in {a:}), a:\n 1)"
+    assert_syntax_error(%q{
+      1 in a, b
+    }, /unexpected/, '[ruby-core:95098]')
+    assert_syntax_error(%q{
+      1 in a:
+    }, /unexpected/, '[ruby-core:95098]')
+  end
 end
 
 
@@ -1214,6 +1220,33 @@ describe "custom tests" do
       in a:, **b
         a == 0 && b == {b: 1}
       end
+  end
+
+  # in with hash
+  assert_block do
+    {a: [0, 1, 2]} in {a:}
+    a == [0, 1, 2]
+  end
+
+  # in with hash and array rest
+  assert_block do
+    {a: [0, 1, 2]} in {a: [0, *r]}
+    r == [1, 2]
+  end
+
+  # non-matching in
+  assert_block do
+    if 0 in 1 | 2
+      flunk
+    else
+      true
+    end
+  end
+
+  # non-matching with match var
+  assert_block do
+    {a:0, b: 1} in {c:, **nil}
+    c.nil?
   end
 end
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Support `in` modifier:

```ruby
{a:1, b: 2} in {a:, **}
p a #=> 1
```

### What changes did you make? (overview)

Enhanced `Rewriters::PatternMatching` to handle `match_in` nodes.

Also, added support for `**nil` patterns for hashes.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md
