### PR TITLE
Fix Zeitwerk/autoload compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ unless ENV["USE_RUBYGEMS_PARSER"] == "1"
     gem "parser", "~> 2.7.0.100"
   end
 end
+
+gem "zeitwerk"

--- a/lib/ruby-next/language/runtime.rb
+++ b/lib/ruby-next/language/runtime.rb
@@ -70,11 +70,13 @@ module Kernel
 
     return false if $LOADED_FEATURES.include?(realpath)
 
+    $LOADED_FEATURES << realpath
+
     RubyNext::Language::Runtime.load(realpath)
 
-    $LOADED_FEATURES << realpath
     true
   rescue => e
+    $LOADED_FEATURES.delete realpath
     warn "RubyNext failed to require '#{path}': #{e.message}"
     require_without_ruby_next(path)
   end

--- a/spec/integration/fixtures/zeitwerk/beach.rb
+++ b/spec/integration/fixtures/zeitwerk/beach.rb
@@ -1,0 +1,18 @@
+class Array
+  alias deconstruct to_a
+end
+
+class Beach < Place
+  def self.call(*temperature)
+    case temperature
+    in :celcius | :c, (20..45)
+      :favorable
+    in :kelvin | :k, (293..318)
+      :scientifically_favorable
+    in :fahrenheit | :f, (68..113)
+      :favorable_in_us
+    else
+      :avoid_beach
+    end
+  end
+end

--- a/spec/integration/fixtures/zeitwerk/place.rb
+++ b/spec/integration/fixtures/zeitwerk/place.rb
@@ -1,0 +1,2 @@
+class Place
+end

--- a/spec/integration/fixtures/zeitwerk/test.rb
+++ b/spec/integration/fixtures/zeitwerk/test.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require "ruby-next/language/runtime"
+
+RubyNext::Language::Runtime.watch_dirs << __dir__
+
+require "zeitwerk"
+
+loader = Zeitwerk::Loader.new
+loader.push_dir(File.join(__dir__))
+loader.setup
+
+p Beach.(:k, 304) #=> :scientifically_favorable

--- a/spec/integration/zeitwerk_spec.rb
+++ b/spec/integration/zeitwerk_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative "../support/command_testing"
+
+using CommandTesting
+
+describe "zeitwerk compatibility" do
+  it "works" do
+    # Zeitwerk doesn't support JRuby
+    # https://github.com/fxn/zeitwerk/issues/6#issuecomment-457863863
+    skip if defined? JRUBY_VERSION
+    run(
+      "ruby -rbundler/setup -I#{File.join(__dir__, "../../lib")} "\
+      "#{File.join(__dir__, "fixtures", "zeitwerk", "test.rb")}"
+    ) do |_status, output, _err|
+      output.should include("scientifically_favorable")
+    end
+  end
+end


### PR DESCRIPTION
### What is the purpose of this pull request?

Make runtime transpiling work with Rails 6 apps.

### What changes did you make?

Add feature to $LOADED_FEATURES before evaluating to make autoload think it's been loaded (otherwise Zeitwerk would try to autoload the constant during its definition).

### Checklist

- [x] I've added tests for this change
