### PR TITLE
Refactor pattern matching predicates

### DIFF
--- a/benchmarks/pattern_matching/cases/github_webhook.rb
+++ b/benchmarks/pattern_matching/cases/github_webhook.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Hack to use bundled benchmark-driver
+module Bundler
+  def self.with_unbundled_env(&block); yield; end
+end
+
+require "benchmark_driver"
+
+require "ruby-next/language"
+
+source = %{
+def call(event)
+  case event
+    in {type: "issue_comment", action: "created", issue: {user: {login:}}}
+      [:issue, login]
+    in {type: "pull_request", action: "opened", pull_request: {user: {login:}}}
+      [:pr, login]
+    end
+end
+}
+
+next_source = RubyNext::Language.transform(source).gsub! "def call(", "def call_next("
+
+Benchmark.driver do |x|
+  x.prelude %Q{
+    #{source}
+
+    #{next_source}
+
+    USER = {login: "palkan"}
+    PR = {type: "pull_request", action: "opened", pull_request: {user: USER}}
+    raise "Assertion failed" if call(PR) != call_next(PR)
+  }
+  x.report "baseline (last pattern)", %{ call(PR) }
+  x.report "transpiled (last pattern)", %{ call_next(PR) }
+end

--- a/lib/ruby-next/core/struct/deconstruct_keys.rb
+++ b/lib/ruby-next/core/struct/deconstruct_keys.rb
@@ -8,8 +8,6 @@ RubyNext::Core.patch Struct, method: :deconstruct_keys, version: "2.7" do
 
       return to_h unless keys
 
-      return {} if size < keys.size
-
       keys.each_with_object({}) do |k, acc|
         # if k is Symbol and not a member of a Struct return {}
         next if (Symbol === k || String === k) && !members.include?(k.to_sym)

--- a/spec/language/custom_pattern_matching_spec.rb
+++ b/spec/language/custom_pattern_matching_spec.rb
@@ -96,6 +96,56 @@ describe "custom tests" do
     end
   end
 
+  it "nested alternation" do
+    assert_block do
+      case [[1], ["2"]]
+        in [[0] | nil, _]
+          false
+        in [[1], [1]]
+          false
+        in [[1], [2 | "2"]]
+          true
+      end
+    end
+
+    assert_block do
+      case [1, 2]
+        in [0, _] | {a: 0}
+          false
+        in {a: 1, b: 2} | [1, 2]
+          true
+      end
+    end
+  end
+
+  describe "multi-level patterns" do
+    it "with arrays" do
+      assert_block do
+        case [[1], [2]]
+          in [[0], _]
+            false
+          in [[1], [1]]
+            false
+          in [[1], [2]]
+            true
+        end
+      end
+    end
+
+    it "with hashes" do
+      assert_block do
+        case {a: {a: 1, b: 1}, b: {a: 1, b: 2}}
+          in {a: {a: 0}}
+            false
+          in {a: {a: 1}, b: {b: 1}}
+            false
+          in {a: {a: 1}, b: {b: 2}}
+            true
+        end
+      end
+    end
+  end
+
   describe "AS pattern" do
     it "can be used with array pattern" do
       eval(<<~RUBY, binding).should == [2, 3]


### PR DESCRIPTION
### What is the purpose of this pull request?

Standardize PM rewriter internals and improve the performance of the resulting code.

### What changes did you make? (overview)

- [x] Added `cases/github_webhook.rb` benchmark for hash patterns

```ruby
case event
  in {type: "issue_comment", action: "created", issue: {user: {login:}}}
    [:issue, login]
  in {type: "pull_request", action: "opened", pull_request: {user: {login:}}}
    [:pr, login]
end
```

- [x] Introduced `PatternMatching::Predicates` to handle all the logic of re-using pattern matching predicates (`respond_to` checks, type checks, key presence, etc.)

The goal is to implement the following formal algorithm.
Consider the example code and the corresponding predicate chains:

```ruby
case val
in [:ok, 200] #=> [:respond_to_deconstruct, :deconstruct_type, :arr_size_is_2]
in [:created, 201] #=> [:respond_to_deconstruct, :deconstruct_type, :arr_size_is_2]
in [401 | 403] #=> [:respond_to_deconstruct, :deconstruct_type, :arr_size_is_1]
end
```

We can minimize the number of predicate calls by storing the intermediate values (prefixed with `p_`) and using them in the subsequent calls:

```ruby
 case val
 in [:ok, 200] #=> [:respond_to_deconstruct, :deconstruct_type, :arr_size_is_2]
 in [:created, 201] #=> [:p_deconstructed, :p_arr_size_2]
 in [401 | 403] #=> [:p_deconstructed, :arr_size_is_1]
 end
```

- [x] Avoid checking the type of `#deconstruct_keys` more than once.
**NOTE**: this optimization improves the performance but deviates from the MRI, 'cause it performs this check for every pattern. In theory, you can write a code that would break (if you return different types depending on the passed keys set but you shouldn't do that).

- [x] Check for required keys presence first in hash patterns.
Apart from the faster unmatches, we can also re-use key-checking predicates. **NOTE:** We assume that the following holds: if K1 is a subset of K2 then `deconstruct_keys(K1)` is a sub-hash of `deconstruct_keys(K2)`. That's why we slightly updated the behaviour of `Struct#deconstruct_keys` (see also https://bugs.ruby-lang.org/issues/16660#change-84488).

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md
