### PR TITLE
Do not assign _ in patterns

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,3 +45,7 @@ Lint/AmbiguousBlockAssociation:
 
 Naming/FileName:
   Enabled: false
+
+Lint/BooleanSymbol:
+  Exclude:
+    - 'lib/ruby-next/language/rewriters/**/*.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master
 
+- Optimize pattern matching transpiled code. ([@palkan][])
+
+For array patterns, transpiled code is ~1.5-2x faster than native.
+For hash patterns it's about the same.
+
 - Pattern matching is 100% compatible with RubySpec. ([@palkan][])
 
 - Add `Symbol#start_with?/end_with?`. ([@palkan][])

--- a/benchmarks/pattern_matching/underscore.rb
+++ b/benchmarks/pattern_matching/underscore.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Hack to use bundled benchmark-driver
+module Bundler
+  def self.with_unbundled_env(&block); yield; end
+end
+
+require "benchmark_driver"
+
+require "ruby-next/language"
+
+source = %{
+def call(val)
+  case val
+    in [_]
+      1
+    in [_, _]
+      2
+    in [_, _, _]
+      3
+  end
+end
+}
+
+next_source = RubyNext::Language.transform(source).gsub! "def call(", "def call_next("
+
+Benchmark.driver do |x|
+  x.prelude %Q{
+    #{source}
+
+    #{next_source}
+
+    raise "Assertion failed" if call([1, 2, 3]) != call_next([1, 2, 3])
+  }
+  x.report "baseline (last pattern)", %{ call([201, :x, ""]) }
+  x.report "transpiled (last pattern)", %{ call_next([201, :x, ""]) }
+end

--- a/spec/language/pattern_matching_spec.rb
+++ b/spec/language/pattern_matching_spec.rb
@@ -324,7 +324,7 @@ ruby_version_is "2.7" do
         eval(<<~RUBY, binding).should == 2
           case [0, 1, 2]
             in [0, _, _]
-              _
+              2
           end
         RUBY
       end


### PR DESCRIPTION
The _ variable is not meant for binding semnatically, so we can avoid assigning it for better performance.

For `benchmarks/pattern_matching/underscore.rb`:

```
# Without optimization
Comparison:
transpiled (last pattern):   2575858.5 i/s 
  baseline (last pattern):   1625193.4 i/s - 1.58x  slower

# With optimization
Comparison:
transpiled (last pattern):   2212582.0 i/s 
  baseline (last pattern):   1632729.4 i/s - 1.36x  slower
```