### PR TITLE
Actualize specs and enable syntax testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## master
 
+- Raise `SyntaxError` when parsing fails. ([@palkan][])
+
+Previously, we let Parser to raise its `Parser::SyntaxError` but some exceptions
+are not reported by Parser and should be handled by transpiler (and we raised `SyntaxError` in that case, as MRI does).
+
+This change unifies the exceptions raised during transpiling.
+
 ## 0.6.0 (2020-04-23)
 
 - Changed the way edge/proposed features are activated. ([@palkan][])

--- a/lib/ruby-next/language/parser.rb
+++ b/lib/ruby-next/language/parser.rb
@@ -23,6 +23,8 @@ module RubyNext
         end
 
         parser.parse(buffer)
+      rescue ::Parser::SyntaxError => e
+        raise ::SyntaxError, e.message
       end
 
       def parse_with_comments(source, file = "(string)")
@@ -31,6 +33,8 @@ module RubyNext
         end
 
         parser.parse_with_comments(buffer)
+      rescue ::Parser::SyntaxError => e
+        raise ::SyntaxError, e.message
       end
     end
   end

--- a/lib/ruby-next/language/rewriters/method_reference.rb
+++ b/lib/ruby-next/language/rewriters/method_reference.rb
@@ -28,12 +28,6 @@ module RubyNext
             ]
           )
         end
-
-        begin
-          transform(SYNTAX_PROBE)
-        rescue ::Parser::SyntaxError
-          warn_custom_parser_required_for("method reference")
-        end
       end
     end
   end

--- a/spec/core/array/fixtures/classes.rb
+++ b/spec/core/array/fixtures/classes.rb
@@ -1,5 +1,3 @@
-# source: https://github.com/ruby/spec/blob/master/core/array/fixtures/classes.rb 
-
 class Object
   # This helper is defined here rather than in MSpec because
   # it is only used in #pack specs.

--- a/spec/language/delegation_spec.rb
+++ b/spec/language/delegation_spec.rb
@@ -1,21 +1,14 @@
+# source: https://github.com/ruby/spec/blob/249a36c2e9fcddbb208a0d618d05f6bd9a64fd17/language/delegation_spec.rb#L1
+
 require_relative '../spec_helper'
+require_relative 'fixtures/delegation'
 
 using RubyNext::Language::ClassEval
 
 ruby_version_is "2.7" do
-  describe "args forwarding def(...)" do
-    class F
-      def target(*args, **kwargs)
-        [args, kwargs]
-      end
-
-      def target_block(*args, **kwargs)
-        yield [kwargs, args]
-      end
-    end
-
+  describe "delegation with def(...)" do
     it "delegates rest and kwargs" do
-      a = Class.new(F)
+      a = Class.new(DelegationSpecs::Target)
       a.class_eval(<<-RUBY)
         def delegate(...)
           target(...)
@@ -26,7 +19,7 @@ ruby_version_is "2.7" do
     end
 
     it "delegates block" do
-      a = Class.new(F)
+      a = Class.new(DelegationSpecs::Target)
       a.class_eval(<<-RUBY)
         def delegate_block(...)
           target_block(...)

--- a/spec/language/fixtures/delegation.rb
+++ b/spec/language/fixtures/delegation.rb
@@ -1,0 +1,11 @@
+module DelegationSpecs
+  class Target
+    def target(*args, **kwargs)
+      [args, kwargs]
+    end
+
+    def target_block(*args, **kwargs)
+      yield [kwargs, args]
+    end
+  end
+end

--- a/spec/language/numbered_parameters_spec.rb
+++ b/spec/language/numbered_parameters_spec.rb
@@ -1,4 +1,4 @@
-# source: https://github.com/ruby/spec/ruby/language/numbered_parameters_spec.rb
+# source: https://github.com/ruby/spec/blob/249a36c2e9fcddbb208a0d618d05f6bd9a64fd17/language/numbered_parameters_spec.rb
 
 require_relative '../spec_helper'
 
@@ -31,10 +31,9 @@ ruby_version_is "2.7" do
     end
 
     it "can not be used in both outer and nested blocks at the same time" do
-      skip
       -> {
         eval("-> { _1; -> { _2 } }")
-      }.should raise_error(SyntaxError, /numbered parameter is already used in.+ outer block here/m)
+      }.should raise_error(SyntaxError, /numbered parameter is already used/m)
     end
 
     it "can be overwritten with local variable" do
@@ -45,7 +44,7 @@ ruby_version_is "2.7" do
         CODE
       end
     end
-\
+
     it "warns when numbered parameter is overriten with local variable" do
       skip
       -> {
@@ -54,7 +53,6 @@ ruby_version_is "2.7" do
     end
 
     it "raises SyntaxError when block parameters are specified explicitly" do
-      skip
       -> { eval("-> () { _1 }")         }.should raise_error(SyntaxError, /ordinary parameter is defined/)
       -> { eval("-> (x) { _1 }")        }.should raise_error(SyntaxError, /ordinary parameter is defined/)
 

--- a/spec/language/pattern_matching_spec.rb
+++ b/spec/language/pattern_matching_spec.rb
@@ -3,7 +3,6 @@
 # NOTE: the following changes to the original code should be made:
 # - Add `using RubyNext::Language::Eval`
 # - Remove expected messages from SyntaxError
-# - Replace SyntaxError with Parser::SyntaxError
 # - Add binding to all eval calls (e.g., `eval <<~CODE` => `eval(<<~CODE, binding)`), move locals to eval when necessary
 # - Skip warnings specs
 
@@ -78,7 +77,7 @@ ruby_version_is "2.7" do
             in []
           end
         RUBY
-      }.should raise_error(Parser::SyntaxError)
+      }.should raise_error(SyntaxError)
 
       -> {
         eval(<<~RUBY, binding)
@@ -87,7 +86,7 @@ ruby_version_is "2.7" do
             when 1 == 1
           end
         RUBY
-      }.should raise_error(Parser::SyntaxError)
+      }.should raise_error(SyntaxError)
     end
 
     it "checks patterns until the first matching" do
@@ -132,7 +131,7 @@ ruby_version_is "2.7" do
               true
           end
         RUBY
-      }.should raise_error(Parser::SyntaxError, /unexpected/)
+      }.should raise_error(SyntaxError, /unexpected/)
     end
 
     describe "guards" do
@@ -352,7 +351,7 @@ ruby_version_is "2.7" do
               in [a, a]
             end
           RUBY
-        }.should raise_error(Parser::SyntaxError)
+        }.should raise_error(SyntaxError)
       end
 
       it "supports existing variables in a pattern specified with ^ operator" do
@@ -394,7 +393,7 @@ ruby_version_is "2.7" do
               false
             end
           RUBY
-        }.should raise_error(Parser::SyntaxError)
+        }.should raise_error(SyntaxError)
       end
     end
 
@@ -759,7 +758,7 @@ ruby_version_is "2.7" do
               in {"a" => 1}
             end
           RUBY
-        }.should raise_error(Parser::SyntaxError, /unexpected/)
+        }.should raise_error(SyntaxError, /unexpected/)
       end
 
       it "does not support string interpolation in keys" do
@@ -771,7 +770,7 @@ ruby_version_is "2.7" do
               in {"#{x}": 1}
             end
           RUBY
-        }.should raise_error(Parser::SyntaxError, /symbol literal with interpolation is not allowed/)
+        }.should raise_error(SyntaxError, /symbol literal with interpolation is not allowed/)
       end
 
       it "raise SyntaxError when keys duplicate in pattern" do
@@ -781,7 +780,7 @@ ruby_version_is "2.7" do
               in {a: 1, b: 2, a: 3}
             end
           RUBY
-        }.should raise_error(Parser::SyntaxError)
+        }.should raise_error(SyntaxError)
       end
 
       it "matches an object with #deconstruct_keys method which returns a Hash with equal keys and each value in Hash matches value in pattern" do

--- a/spec/language/ruby_args_forward_spec.rb
+++ b/spec/language/ruby_args_forward_spec.rb
@@ -1,4 +1,4 @@
-# source: https://github.com/ruby/ruby/blob/master/test/ruby/test_syntax.rb#L1477
+# source: https://github.com/ruby/ruby/blob/b609bdeb5307e280137b4b2838af0fe4e4b46f1c/test/ruby/test_syntax.rb#L1474
 
 require_relative '../test_unit_to_mspec'
 
@@ -6,6 +6,29 @@ using RubyNext::Language::InstanceEval
 using TestUnitToMspec
 
 describe "args forwarding def(...)" do
+  it "syntax" do
+    assert_valid_syntax('def foo(...) bar(...) end')
+    assert_valid_syntax('def foo(...) end')
+    assert_syntax_error('iter do |...| end', /unexpected/)
+    assert_syntax_error('iter {|...|}', /unexpected/)
+    assert_syntax_error('->... {}', /unexpected/)
+    assert_syntax_error('->(...) {}', /unexpected/)
+    assert_syntax_error('def foo(x, y, z) bar(...); end', /unexpected/)
+    assert_syntax_error('def foo(x, y, z) super(...); end', /unexpected/)
+    assert_syntax_error('def foo(...) yield(...); end', /unexpected/)
+    assert_syntax_error('def foo(...) return(...); end', /unexpected/)
+    assert_syntax_error('def foo(...) a = (...); end', /unexpected/)
+    assert_syntax_error('def foo(...) [...]; end', /unexpected/)
+    assert_syntax_error('def foo(...) foo[...]; end', /unexpected/)
+    assert_syntax_error('def foo(...) foo[...] = x; end', /unexpected/)
+    assert_syntax_error('def foo(...) foo(...) { }; end', /both block arg and actual block given/)
+    assert_syntax_error('def foo(...) defined?(...); end', /unexpected/)
+  end
+
+  # FIXME: figure out how to deal with full kwargs separation
+  # https://github.com/ruby/ruby/pull/2794
+  next if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
+
   obj1 = Object.new
   def obj1.bar(*args, **kws, &block)
     if block
@@ -63,8 +86,6 @@ describe "args forwarding def(...)" do
       }
       assert_equal(-1, obj.method(:foo).arity)
 
-      # FIXME: As is as this patch is released: https://github.com/ruby/ruby/commit/b609bdeb5307e280137b4b2838af0fe4e4b46f1c
-      next if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
       parameters = obj.method(:foo).parameters
       assert_equal(:rest, parameters.dig(0, 0))
       assert_equal(:block, parameters.dig(1, 0))

--- a/spec/language/ruby_pattern_matching_spec.rb
+++ b/spec/language/ruby_pattern_matching_spec.rb
@@ -1,9 +1,10 @@
-# source: https://github.com/ruby/ruby/blob/master/test/ruby/test_pattern_matching.rb
+# source: https://github.com/ruby/ruby/blob/501f2c44e6ae79c02a5c4d0f872fc7fa77258fcf/test/ruby/test_pattern_matching.rb
 #
 # How to sync tests:
 #  - Copy `eval` contents from ruby tests and paste here
 #  - Include refinement into eval (for JRuby)
 #  - Drop experimental warning tests
+#  - Comment some syntax specs (see notes)
 #  - Extract refeniments modules from the test class and refinements test at the end of the file
 
 require_relative '../test_unit_to_mspec'
@@ -99,18 +100,6 @@ class TestPatternMatching < Test::Unit::TestCase
         in 1
         end
       end
-    end
-
-    assert_block do
-      verbose, $VERBOSE = $VERBOSE, nil # suppress "warning: Pattern matching is experimental, and the behavior may change in future versions of Ruby!"
-      eval(%q{
-        case true
-        in a
-          a
-        end
-      })
-    ensure
-      $VERBOSE = verbose
     end
 
     assert_block do
@@ -431,7 +420,7 @@ END
       end
     end
 
-     assert_block do
+    assert_block do
       [[], C.new([])].all? do |i|
         case i
         in 0,;
@@ -1039,15 +1028,44 @@ END
       end
     }, /duplicated key name/)
 
-    assert_syntax_error(%q{
-      case _
-      in a?:
-      end
-    }, /key must be valid as local variables/)
+    # FIX: parser
+    # assert_syntax_error(%q{
+    #   case _
+    #   in a?:
+    #   end
+    # }, /key must be valid as local variables/)
 
     assert_block do
       case {a?: true}
       in a?: true
+        true
+      end
+    end
+
+    assert_block do
+      case {a: 0, b: 1}
+      in {a: 1,}
+        false
+      in {a:,}
+        _a = a
+        true
+      end
+    end
+
+    assert_block do
+      case {a: 0}
+      in {a: 1
+      }
+        false
+      in {a:
+            2}
+        false
+      in a: {b:}, c:
+        _b = b
+        p c
+      in {a:
+      }
+        _a = a
         true
       end
     end
@@ -1071,11 +1089,12 @@ END
       end
     }, /symbol literal with interpolation is not allowed/)
 
-    assert_syntax_error(%q{
-      case _
-      in "#{a}":
-      end
-    }, /symbol literal with interpolation is not allowed/)
+    # FIX: parser
+    # assert_syntax_error(%q{
+    #   case _
+    #   in "#{a}":
+    #   end
+    # }, /symbol literal with interpolation is not allowed/)
   end
 
   def test_paren
@@ -1236,7 +1255,8 @@ END
     assert_raise(NoMatchingPatternError) do
       {a: 1} in {a: 0}
     end
-    assert_syntax_error("if {} in {a:}; end", /void value expression/)
+    # WONTFIX:
+    # assert_syntax_error("if {} in {a:}; end", /void value expression/)
     assert_syntax_error(%q{
       1 in a, b
     }, /unexpected/, '[ruby-core:95098]')

--- a/spec/test_unit_to_mspec.rb
+++ b/spec/test_unit_to_mspec.rb
@@ -25,12 +25,13 @@ module TestUnitToMspec
       block.should_not raise_error
     end
 
-    # We do not check syntax, so make it no-op
-    def assert_syntax_error(*)
-      true.should == true
+    def assert_syntax_error(str, *)
+      -> { RubyNext::Language.transform(str) }.should raise_error(SyntaxError)
     end
 
-    alias assert_valid_syntax assert_syntax_error
+    def assert_valid_syntax(str)
+      -> { RubyNext::Language.transform(str) }.should_not raise_error
+    end
 
     # Let's skip for now
     def assert_warning(*)


### PR DESCRIPTION
### What changes did you make? (overview)

- [x] Raise `SyntaxError` instead of `Parser::SyntaxError` if parsing fails
- [x] Implement `assert_valid_syntax` etc.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
