### PR TITLE
Add endless def support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Add endless methods support. ([@palkan][])
+
+Now you can write `def foo() = :bar`.
+
 ## 0.7.0 (2020-04-29)
 
 - Try to auto-transpile the source code on load in `.setup_gem_load_path` if transpiled files are missing. ([@palkan][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Add right-hand assignment support. ([@palkan][])
+
+It is real: `13.divmod(5) => a, b`.
+
 - Add endless methods support. ([@palkan][])
 
 Now you can write `def foo() = :bar`.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ You can change the transpiler mode:
 - Via environmental variable `RUBY_NEXT_TRANSPILE_MODE=rewrite`.
 - Via CLI option ([see below](#cli)).
 
+**NOTE:** For the time being, Unparser [doesn't support](https://github.com/mbj/unparser/pull/142) new Ruby 2.7 AST nodes, so we always use rewrite mode in Ruby 2.7+.
+
 ## CLI
 
 Ruby Next ships with the command-line interface (`ruby-next`) which provides the following functionality:

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ $ gem install ruby-next
 $ ruby -ruby-next -e "
 def greet(val) =
   case val
-    in hello: hello if hello =~ /human/
-      puts '🙂'
+    in hello: hello if hello =~ /human/i
+      '🙂'
     in hello: 'martian'
-      puts '👽'
+      '👽'
     end
 
-greet(hello: 'martian')
+greet(hello: 'martian') => greeting
+puts greeting
 "
 
 => 👽
@@ -437,6 +438,8 @@ require "ruby-next/language/runtime"
 ### Supported edge features
 
 - "Endless" method definition (`def foo() = 42`) ([#16746](https://bugs.ruby-lang.org/issues/16746)).
+
+- Right-hand assignment (`13.divmod(5) => a,b`) ([#15921](https://bugs.ruby-lang.org/issues/15921))
 
 ### Supported proposed features
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,15 @@ $ gem install ruby-next
 
 # Call ruby with -ruby-next flag
 $ ruby -ruby-next -e "
- case {hello: 'martian'}
- in hello: hello if hello =~ /human/
-   puts '🙂'
- in hello: 'martian'
-   puts '👽'
- end
+def greet(val) =
+  case val
+    in hello: hello if hello =~ /human/
+      puts '🙂'
+    in hello: 'martian'
+      puts '👽'
+    end
+
+greet(hello: 'martian')
 "
 
 => 👽
@@ -431,11 +434,11 @@ require "ruby-next/language/runtime"
 
 ### Supported edge features
 
-Not yet.
+- "Endless" method definition (`def foo() = 42`) ([#16746](https://bugs.ruby-lang.org/issues/16746)).
 
 ### Supported proposed features
 
-- _Method reference_ operator (`.:`) ([link](https://bugs.ruby-lang.org/issues/13581)).
+- _Method reference_ operator (`.:`) ([#13581](https://bugs.ruby-lang.org/issues/13581)).
 
 ## Contributing
 

--- a/SUPPORTED_FEATURES.md
+++ b/SUPPORTED_FEATURES.md
@@ -61,3 +61,7 @@ You can still use this feature with Ruby Next by enabling it explicitly (see [Re
 - (_WONTFIX_) Startless ranges (`..1` or `...1`) ([ref](https://rubyreferences.github.io/rubychanges/2.7.html#beginless-range))
 
 The possible translation depends on the _end_ type which could hardly be inferred from the source code.
+
+### 2.8
+
+- "Endless" method definition (`def foo() = 42`) ([#16746](https://bugs.ruby-lang.org/issues/16746))

--- a/SUPPORTED_FEATURES.md
+++ b/SUPPORTED_FEATURES.md
@@ -65,3 +65,5 @@ The possible translation depends on the _end_ type which could hardly be inferre
 ### 2.8
 
 - "Endless" method definition (`def foo() = 42`) ([#16746](https://bugs.ruby-lang.org/issues/16746))
+
+- Right-hand assignment (`13.divmod(5) => a,b`) ([#15921](https://bugs.ruby-lang.org/issues/15921))

--- a/bin/transform
+++ b/bin/transform
@@ -5,11 +5,10 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "bundler/setup"
 
-require "ruby-next/language"
+ENV["RUBY_NEXT_EDGE"] = "1"
+ENV["RUBY_NEXT_PROPOSED"] = "1"
 
-# optional parsers
-require "ruby-next/language/rewriters/method_reference"
-RubyNext::Language.rewriters << RubyNext::Language::Rewriters::MethodReference
+require "ruby-next/language"
 
 contents =
   if File.exist?(ARGV[0])

--- a/gemfiles/parser.gemfile
+++ b/gemfiles/parser.gemfile
@@ -1,0 +1,5 @@
+if ENV["LOCAL_PARSER"]
+  gem "ruby-next-parser", path: ENV["LOCAL_PARSER"]
+else
+  gem "ruby-next-parser"
+end

--- a/gemfiles/rubocop.gemfile
+++ b/gemfiles/rubocop.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org" do
   gem "rubocop-md", "~> 0.3"
   gem "standard", "~> 0.2.0"
-  gem "ruby-next-parser"
+
+  eval_gemfile "parser.gemfile"
 end

--- a/lib/ruby-next.rb
+++ b/lib/ruby-next.rb
@@ -11,10 +11,10 @@ module RubyNext
 
   # Defines last minor version for every major version
   LAST_MINOR_VERSIONS = {
-    2 => 7
+    2 => 8
   }.freeze
 
-  LATEST_VERSION = [2, 7].freeze
+  LATEST_VERSION = [2, 8].freeze
 
   class << self
     def next_version(version = RUBY_VERSION)

--- a/lib/ruby-next/commands/nextify.rb
+++ b/lib/ruby-next/commands/nextify.rb
@@ -97,7 +97,13 @@ module RubyNext
         rewriters = Language.rewriters.select { |rw| rw.unsupported_version?(version) }
 
         context = Language::TransformContext.new
-        new_contents = Language.transform contents, context: context, rewriters: rewriters
+
+        new_contents =
+          if Gem::Version.new(version) >= Gem::Version.new("2.7.0") && !defined?(Unparser::Emitter::CaseMatch)
+            Language.rewrite contents, context: context, rewriters: rewriters
+          else
+            Language.transform contents, context: context, rewriters: rewriters
+          end
 
         return unless context.dirty?
 

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -84,7 +84,7 @@ module RubyNext
 
       def runtime!
         if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0") && !defined?(Unparser::Emitter::CaseMatch)
-          RubyNext.warn "Ruby Next fallbacks to \"rewrite\" transpiling mode since Unparser doesn't support 2.7 AST yet.\n"
+          RubyNext.warn "Ruby Next fallbacks to \"rewrite\" transpiling mode since Unparser doesn't support 2.7 AST yet.\n" \
             "See https://github.com/mbj/unparser/pull/142"
           self.mode = :rewrite
         end

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -83,6 +83,12 @@ module RubyNext
       end
 
       def runtime!
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0") && !defined?(Unparser::Emitter::CaseMatch)
+          RubyNext.warn "Ruby Next fallbacks to \"rewrite\" transpiling mode since Unparser doesn't support 2.7 AST yet.\n"
+            "See https://github.com/mbj/unparser/pull/142"
+          self.mode = :rewrite
+        end
+
         @runtime = true
       end
 

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "ruby-next-parser", ">= 2.8.0.0"
+gem "ruby-next-parser", ">= 2.8.0.3"
 gem "unparser", ">= 0.4.7"
 
 require "set"

--- a/lib/ruby-next/language/edge.rb
+++ b/lib/ruby-next/language/edge.rb
@@ -4,3 +4,6 @@
 
 require "ruby-next/language/rewriters/endless_method"
 RubyNext::Language.rewriters << RubyNext::Language::Rewriters::EndlessMethod
+
+require "ruby-next/language/rewriters/right_hand_assignment"
+RubyNext::Language.rewriters << RubyNext::Language::Rewriters::RightHandAssignment

--- a/lib/ruby-next/language/edge.rb
+++ b/lib/ruby-next/language/edge.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
 # Load edge Ruby features
+
+require "ruby-next/language/rewriters/endless_method"
+RubyNext::Language.rewriters << RubyNext::Language::Rewriters::EndlessMethod

--- a/lib/ruby-next/language/rewriters/args_forward.rb
+++ b/lib/ruby-next/language/rewriters/args_forward.rb
@@ -25,21 +25,23 @@ module RubyNext
         end
 
         def on_send(node)
-          return unless node.children[2]&.type == :forwarded_args
+          return super(node) unless node.children[2]&.type == :forwarded_args
 
           replace(node.children[2].loc.expression, "*#{REST}, &#{BLOCK}")
 
-          node.updated(
-            nil,
-            [
-              *node.children[0..1],
-              *forwarded_args
-            ]
+          process(
+            node.updated(
+              nil,
+              [
+                *node.children[0..1],
+                *forwarded_args
+              ]
+            )
           )
         end
 
         def on_super(node)
-          return unless node.children[0]&.type == :forwarded_args
+          return super(node) unless node.children[0]&.type == :forwarded_args
 
           replace(node.children[0].loc.expression, "*#{REST}, &#{BLOCK}")
 

--- a/lib/ruby-next/language/rewriters/base.rb
+++ b/lib/ruby-next/language/rewriters/base.rb
@@ -78,10 +78,6 @@ module RubyNext
           def transform(source)
             Language.transform(source, rewriters: [self], using: false)
           end
-
-          def warn_custom_parser_required_for(feature)
-            RubyNext.warn(CUSTOM_PARSER_REQUIRED % feature)
-          end
         end
 
         attr_reader :locals

--- a/lib/ruby-next/language/rewriters/endless_method.rb
+++ b/lib/ruby-next/language/rewriters/endless_method.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module RubyNext
+  module Language
+    module Rewriters
+      class EndlessMethod < Base
+        SYNTAX_PROBE = "obj = Object.new; def obj.foo() = 42"
+        MIN_SUPPORTED_VERSION = Gem::Version.new("2.8.0")
+
+        def on_def_e(node)
+          context.track! self
+
+          replace(node.loc.assignment, "; ")
+          insert_after(node.loc.expression, "; end")
+
+          process(
+            node.updated(
+              :def,
+              node.children
+            )
+          )
+        end
+
+        def on_defs_e(node)
+          context.track! self
+
+          replace(node.loc.assignment, "; ")
+          insert_after(node.loc.expression, "; end")
+
+          process(
+            node.updated(
+              :defs,
+              node.children
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-next/language/rewriters/right_hand_assignment.rb
+++ b/lib/ruby-next/language/rewriters/right_hand_assignment.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module RubyNext
+  module Language
+    module Rewriters
+      class RightHandAssignment < Base
+        SYNTAX_PROBE = "1 + 2 => a"
+        MIN_SUPPORTED_VERSION = Gem::Version.new("2.8.0")
+
+        def on_rasgn(node)
+          context.track! self
+
+          val_node, asgn_node = *node
+
+          remove(val_node.loc.expression.end.join(asgn_node.loc.expression))
+          insert_before(val_node.loc.expression, "#{asgn_node.loc.expression.source} = ")
+
+          process(
+            asgn_node.updated(
+              nil,
+              asgn_node.children + [val_node]
+            )
+          )
+        end
+
+        def on_mrasgn(node)
+          context.track! self
+
+          lhs, rhs = *node
+
+          replace(lhs.loc.expression.end.join(rhs.loc.expression), ")")
+          insert_before(lhs.loc.expression, "#{rhs.loc.expression.source} = (")
+
+          process(
+            node.updated(
+              :masgn,
+              [rhs, lhs]
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-next/rubocop.rb
+++ b/lib/ruby-next/rubocop.rb
@@ -96,6 +96,20 @@ module RuboCop
           send(:"on_#{body_node.type}", body_node)
         end
       end
+
+      unless method_defined?(:on_rasgn)
+        def on_rasgn(node)
+          val_node, asgn_node = *node
+          send(:"on_#{asgn_node.type}", asgn_node)
+          send(:"on_#{val_node.type}", val_node)
+        end
+
+        def on_mrasgn(node)
+          lhs, rhs = *node
+          send(:"on_#{lhs.type}", lhs)
+          send(:"on_#{rhs.type}", rhs)
+        end
+      end
     end
   end
 end

--- a/lib/ruby-next/rubocop.rb
+++ b/lib/ruby-next/rubocop.rb
@@ -84,6 +84,18 @@ module RuboCop
           send(:"on_#{child.type}", child)
         end
       end
+
+      unless method_defined?(:on_def_e)
+        def on_def_e(node)
+          _name, _args_node, body_node = *node
+          send(:"on_#{body_node.type}", body_node)
+        end
+
+        def on_defs_e(node)
+          _definee_node, _name, _args_node, body_node = *node
+          send(:"on_#{body_node.type}", body_node)
+        end
+      end
     end
   end
 end

--- a/ruby-next-core.gemspec
+++ b/ruby-next-core.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.executables = ["ruby-next"]
 
-  s.add_development_dependency "ruby-next-parser", ">= 2.8.0.3"
+  s.add_development_dependency "ruby-next-parser", ">= 2.8.0.4"
   s.add_development_dependency "unparser", ">= 0.4.7"
 end

--- a/ruby-next-core.gemspec
+++ b/ruby-next-core.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.executables = ["ruby-next"]
 
-  s.add_development_dependency "ruby-next-parser", ">= 2.8.0.0"
+  s.add_development_dependency "ruby-next-parser", ">= 2.8.0.3"
   s.add_development_dependency "unparser", ">= 0.4.7"
 end

--- a/ruby-next.gemspec
+++ b/ruby-next.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "ruby-next-core"
-  s.add_dependency "ruby-next-parser", ">= 2.8.0.0"
+  s.add_dependency "ruby-next-parser", ">= 2.8.0.3"
   s.add_dependency "unparser", ">= 0.4.7"
 end

--- a/ruby-next.gemspec
+++ b/ruby-next.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "ruby-next-core"
-  s.add_dependency "ruby-next-parser", ">= 2.8.0.3"
+  s.add_dependency "ruby-next-parser", ">= 2.8.0.4"
   s.add_dependency "unparser", ">= 0.4.7"
 end

--- a/spec/cli/dummy/namespaced/pattern_matching.rb
+++ b/spec/cli/dummy/namespaced/pattern_matching.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 class B
-  def self.match(val)
+  def self.match(val) =
     case val
     in 1 | 2
       true
     else
       false
     end
-  end
 end

--- a/spec/cli/nextify_spec.rb
+++ b/spec/cli/nextify_spec.rb
@@ -11,21 +11,18 @@ describe "ruby-next nextify" do
     File.delete(File.join(__dir__, "dummy", ".rbnextrc")) if File.exist?(File.join(__dir__, "dummy", ".rbnextrc"))
   end
 
-  it "generates .rbnxt/2.6 folder with the transpiled files required for 2.6" do
-    run_ruby_next "nextify #{File.join(__dir__, "dummy")}" do |_status, _output, err|
-      File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.7", "transpile_me.rb")).should equal true
-      File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.7", "namespaced", "pattern_matching.rb")).should equal true
-      File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.7", "namespaced", "version.rb")).should equal false
-      File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.7", "namespaced", "endless_nameless.rb")).should equal false
-    end
-  end
-
-  it "generates .rbnxt/2.5 folder with the transpiled files required for 2.5" do
-    run_ruby_next "nextify #{File.join(__dir__, "dummy")}" do |_status, _output, err|
+  it "generates .rbnxt/{2.6, 2.7, 2.8} folders with the transpiled files required for each version" do
+    run_ruby_next "nextify #{File.join(__dir__, "dummy")} --proposed --edge" do |_status, _output, err|
       File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.6", "transpile_me.rb")).should equal false
       File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.6", "namespaced", "pattern_matching.rb")).should equal false
       File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.6", "namespaced", "version.rb")).should equal false
       File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.6", "namespaced", "endless_nameless.rb")).should equal true
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.7", "transpile_me.rb")).should equal true
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.7", "namespaced", "pattern_matching.rb")).should equal true
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.7", "namespaced", "version.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.7", "namespaced", "endless_nameless.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.8", "namespaced", "pattern_matching.rb")).should equal true
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "2.8", "namespaced", "endless_nameless.rb")).should equal false
     end
   end
 
@@ -136,6 +133,29 @@ describe "ruby-next nextify" do
       env: {"RUBY_NEXT_PROPOSED" => "0"}
     ) do |_status, _output, err|
       File.exist?(File.join(__dir__, "dummy", ".rbnext", "method_reference_old.rb")).should equal false
+    end
+  end
+
+  it "--edge" do
+    run_ruby_next(
+      "nextify #{File.join(__dir__, "..", "integration", "fixtures", "endless_def.rb")} --edge " \
+      "--transpile-mode=rewrite --min-version=2.7 " \
+      "-o #{File.join(__dir__, "dummy", ".rbnext", "endless_def_old.rb")}",
+      env: {"RUBY_NEXT_EDGE" => "0"}
+    ) do |_status, _output, err|
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "endless_def_old.rb")).should equal true
+      File.read(File.join(__dir__, "dummy", ".rbnext", "endless_def_old.rb")).should include("def greet(val) ;")
+    end
+  end
+
+  it "--edge is not set" do
+    run_ruby_next(
+      "nextify #{File.join(__dir__, "..", "integration", "fixtures", "endless_def.rb")} " \
+      "--transpile-mode=rewrite --min-version=2.7 " \
+      "-o #{File.join(__dir__, "dummy", ".rbnext", "endless_def_old.rb")}",
+      env: {"RUBY_NEXT_EDGE" => "0"}
+    ) do |_status, _output, err|
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "endless_def_old.rb")).should equal false
     end
   end
 

--- a/spec/integration/edge_proposed_spec.rb
+++ b/spec/integration/edge_proposed_spec.rb
@@ -17,4 +17,17 @@ describe "edge/proposed features via require" do
       output.should include("\"status: ok\"\n")
     end
   end
+
+  it "edge features" do
+    cmd = <<~CMD
+      ruby -rbundler/setup -I#{File.join(__dir__, "../../../lib")} -r #{File.join(__dir__, "fixtures", "edge.rb")} \
+      -e "p greet(hello: 'Human'); p greet(hello: 'martian')"
+    CMD
+
+    # Set env var to 0 to make sure we do not shadow it
+    run(cmd, env: {"RUBY_NEXT_EDGE" => "0"}) do |_status, output, _err|
+      output.should include("human\n")
+      output.should include("alien\n")
+    end
+  end
 end

--- a/spec/integration/fixtures/edge.rb
+++ b/spec/integration/fixtures/edge.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require "ruby-next/language"
+
 require "ruby-next/language/edge"
+require "ruby-next/language/proposed"
 
 require "ruby-next/language/runtime"
-RubyNext::Language.watch_dirs << __dir__
-require "txen"
+
+require_relative "endless_def"

--- a/spec/integration/fixtures/endless_def.rb
+++ b/spec/integration/fixtures/endless_def.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+def greet(val) =
+  case val
+    in hello: hello if hello =~ /human/i
+      puts "human"
+    in hello: "martian"
+      puts "alien"
+    end
+
+# p greet(hello: "Human") => 'human'
+# p greet(hello: "martian") => 'alien'

--- a/spec/integration/fixtures/lib/.rbnext/2.8/txen/game.rb
+++ b/spec/integration/fixtures/lib/.rbnext/2.8/txen/game.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Txen
+  module Game
+    def self.failed?(num)
+      (22...).cover?(num)
+    end
+  end
+end

--- a/spec/integration/fixtures/lib/txen/cards.rb
+++ b/spec/integration/fixtures/lib/txen/cards.rb
@@ -9,9 +9,7 @@ module Txen
       in "jack" | "queen" | "king"
         10
       in "ace"
-        # NOTE: original source is changed to test runtime activation
-        # (in the transpiled code you can should see 11)
-        10
+        11
       end
     end
   end

--- a/spec/integration/fixtures/lib/txen/game.rb
+++ b/spec/integration/fixtures/lib/txen/game.rb
@@ -2,8 +2,8 @@
 
 module Txen
   module Game
-    def self.failed?(num)
-      (22...).cover?(num)
-    end
+    # NOTE: original source is changed to test runtime activation
+    # (in the transpiled code you can should see 22)
+    def self.failed?(num) = (23...).cover?(num)
   end
 end

--- a/spec/integration/fixtures/rewrite.rb
+++ b/spec/integration/fixtures/rewrite.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Eternal
+  def self.call
+    case 4
+    in (1..)
+      true
+    else
+      false
+    end => x
+
+    !x
+  end
+
+  # add a method which has different layout in parse/unparse
+  def self.hash() =
+    {
+      a: 1,
+      b: 2
+    }
+end

--- a/spec/integration/fixtures/rubocop/endless_def.rb
+++ b/spec/integration/fixtures/rubocop/endless_def.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Ende
+  def self.version() = "1.0"
+
+  def greet(val) =
+    case val
+      in hello: hello if hello =~ /human/
+        puts "human"
+      in hello: "martian"
+        puts "alien"
+      end
+end

--- a/spec/integration/fixtures/rubocop/right_hand.rb
+++ b/spec/integration/fixtures/rubocop/right_hand.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+def right_hand(a, b)
+  a.divmod(b) => x, y => k, l
+  k + x => z
+
+  y + l + z
+end

--- a/spec/integration/language_spec.rb
+++ b/spec/integration/language_spec.rb
@@ -35,17 +35,4 @@ describe "language features (via -ruby-next)" do
       output.should include("Bob age is 30")
     end
   end
-
-  it "proposed features" do
-    cmd = <<~CMD
-      ruby -rbundler/setup -I#{File.join(__dir__, "../../../lib")} -ruby-next -r #{File.join(__dir__, "fixtures", "method_reference.rb")} \
-      -e "p main({}.to_json); p main({status: :ok}.to_json)"
-    CMD
-
-    # Set env var to 0 to make sure we do not shadow it
-    run(cmd, env: {"RUBY_NEXT_PROPOSED" => "0"}) do |_status, output, _err|
-      output.should include("\"status: \"\n")
-      output.should include("\"status: ok\"\n")
-    end
-  end
 end

--- a/spec/integration/rewrite_spec.rb
+++ b/spec/integration/rewrite_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "../support/command_testing"
+
+using CommandTesting
+
+describe "rewrite mode" do
+  it "preserves lines" do
+    run_ruby_next(
+      "nextify #{File.join(__dir__, "fixtures", "rewrite.rb")} " \
+      "--transpile-mode=rewrite -o stdout --edge --proposed --single-version"
+    ) do |_status, output, err|
+      output.lines.size.should equal(
+        File.read(File.join(__dir__, "fixtures", "rewrite.rb")).lines.size
+      )
+    end
+  end
+end

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -11,7 +11,7 @@ describe "setup load path" do
   end
 
   it "loads correct file versions" do
-    skip if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
+    skip if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.8")
     run_ruby(
       "-I#{File.join(__dir__, "fixtures", "lib")} " \
       "-r txen " \

--- a/spec/integration/uby_next_spec.rb
+++ b/spec/integration/uby_next_spec.rb
@@ -21,4 +21,30 @@ describe "ruby -ruby-next" do
       output.should include("burning_on_the_sun")
     end
   end
+
+  it "proposed features" do
+    cmd = <<~CMD
+      ruby -rbundler/setup -I#{File.join(__dir__, "../../../lib")} -ruby-next -r #{File.join(__dir__, "fixtures", "method_reference.rb")} \
+      -e "p main({}.to_json); p main({status: :ok}.to_json)"
+    CMD
+
+    # Set env var to 0 to make sure we do not shadow it
+    run(cmd, env: {"RUBY_NEXT_PROPOSED" => "0"}) do |_status, output, _err|
+      output.should include("\"status: \"\n")
+      output.should include("\"status: ok\"\n")
+    end
+  end
+
+  it "edge features" do
+    cmd = <<~CMD
+      ruby -rbundler/setup -I#{File.join(__dir__, "../../../lib")} -ruby-next -r #{File.join(__dir__, "fixtures", "endless_def.rb")} \
+      -e "p greet(hello: 'Human'); p greet(hello: 'martian')"
+    CMD
+
+    # Set env var to 0 to make sure we do not shadow it
+    run(cmd, env: {"RUBY_NEXT_EDGE" => "0"}) do |_status, output, _err|
+      output.should include("human\n")
+      output.should include("alien\n")
+    end
+  end
 end

--- a/spec/language/custom_endless_def_spec.rb
+++ b/spec/language/custom_endless_def_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative '../test_unit_to_mspec'
+
+using TestUnitToMspec
+
+describe "custom tests for endless method" do
+  class CustomEndlessDefSpec
+  end
+
+  it "with pattern matching" do
+    a = Class.new(CustomEndlessDefSpec) do
+      def foo(val) =
+        case val
+        in bar:
+          bar
+        in baz:
+          baz
+        end
+    end
+
+    a.new.foo(bar: 1).should == 1
+    a.new.foo(baz: "b").should == "b"
+  end
+
+  it "with args forwarding" do
+    a = Class.new(CustomEndlessDefSpec)
+    a.class_eval do
+      def self.moo(word, num:)
+        word * num
+      end
+
+      def self.foo(...) = moo(...) + moo(...)
+    end
+
+    a.foo("meow", num: 2).should == "meow" * 4
+  end
+end

--- a/spec/language/custom_pattern_matching_spec.rb
+++ b/spec/language/custom_pattern_matching_spec.rb
@@ -3,7 +3,7 @@ require_relative '../test_unit_to_mspec'
 using TestUnitToMspec
 
 # These tests are not copied from ruby/ruby
-describe "custom tests" do
+describe "custom tests for pattern mathing" do
   it "array pattern multiple clauses" do
     # multiple clauses with arrays
     assert_block do

--- a/spec/language/endless_def_spec.rb
+++ b/spec/language/endless_def_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../spec_helper'
+
+using RubyNext::Language::ClassEval
+
+ruby_version_is "2.8" do
+  describe "def x() = y" do
+    class EndlessDefSpec
+    end
+
+    it "without arguments" do
+      a = Class.new(EndlessDefSpec)
+      a.class_eval(<<-RUBY)
+        def num() = 42
+      RUBY
+
+      a.new.num.should == 42
+    end
+
+    it "with arguments" do
+      a = Class.new(EndlessDefSpec)
+      a.class_eval(<<-RUBY)
+        def add(a, b) = a + b
+      RUBY
+
+      a.new.add(1, 4).should == 5
+    end
+
+    it "with multiline body" do
+      a = Class.new(EndlessDefSpec)
+      a.class_eval(<<-RUBY)
+        def fib(n) =
+          if n > 2
+            fib(n - 2) + fib(n - 1)
+          else
+            1
+          end
+      RUBY
+
+      a.new.fib(6).should == 8
+    end
+  end
+end

--- a/spec/language/right_hand_spec.rb
+++ b/spec/language/right_hand_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../spec_helper'
+
+using RubyNext::Language::Eval
+
+ruby_version_is "2.8" do
+  describe "1 => x" do
+    class RightHandSpec
+    end
+
+    it "with expression" do
+      a = 2
+      eval(<<-RUBY, binding)
+        if a > 1
+          1
+        else
+          0
+        end => @x
+      RUBY
+
+      @x.should == 1
+    end
+
+    it "with right-hand method call" do
+      x = eval(<<-RUBY, binding)
+        (5 + 3 => x).
+          then(&:to_s)
+      RUBY
+
+      x.should == "8"
+    end
+  end
+end

--- a/spec/language/ruby_def_spec.rb
+++ b/spec/language/ruby_def_spec.rb
@@ -15,9 +15,8 @@ class TestSyntaxMethodDefEndless < Test::Unit::TestCase
     assert_syntax_error('private def obj.foo = 42', /unexpected '='/)
     assert_valid_syntax('private def obj.foo() = 42')
     assert_valid_syntax('private def obj.inc(x) = x + 1')
-    # TODO: right-hand assignment
-    # eval('def self.inc(x) = x + 1 => @x')
-    # assert_equal(:inc, @x)
+    eval('def self.inc(x) = x + 1 => @x')
+    assert_equal(:inc, @x)
   end
 end
 RUBY

--- a/spec/language/ruby_def_spec.rb
+++ b/spec/language/ruby_def_spec.rb
@@ -1,0 +1,23 @@
+# source: https://github.com/ruby/ruby/blob/1997e10f6caeae49660ceb9342a01a4fd2efc788/test/ruby/test_syntax.rb#L1417
+
+require_relative '../test_unit_to_mspec'
+
+using TestUnitToMspec
+
+eval <<~RUBY, binding, __FILE__, __LINE__
+using TestUnitToMspec
+
+class TestSyntaxMethodDefEndless < Test::Unit::TestCase
+  def test_methoddef_endless
+    assert_syntax_error('private def foo = 42', /unexpected '='/)
+    assert_valid_syntax('private def foo() = 42')
+    assert_valid_syntax('private def inc(x) = x + 1')
+    assert_syntax_error('private def obj.foo = 42', /unexpected '='/)
+    assert_valid_syntax('private def obj.foo() = 42')
+    assert_valid_syntax('private def obj.inc(x) = x + 1')
+    # TODO: right-hand assignment
+    # eval('def self.inc(x) = x + 1 => @x')
+    # assert_equal(:inc, @x)
+  end
+end
+RUBY

--- a/spec/language/ruby_right_hand_spec.rb
+++ b/spec/language/ruby_right_hand_spec.rb
@@ -1,0 +1,18 @@
+# source: https://github.com/ruby/ruby/blob/1997e10f6caeae49660ceb9342a01a4fd2efc788/test/ruby/test_syntax.rb#L1573
+
+require_relative '../test_unit_to_mspec'
+
+using TestUnitToMspec
+
+eval <<~RUBY, binding, __FILE__, __LINE__
+using TestUnitToMspec
+
+class TestRightHandAssignment < Test::Unit::TestCase
+  def test_rightward_assign
+    assert_equal(1, eval("1 => a"))
+    assert_equal([2,3], eval("13.divmod(5) => a,b; [a, b]"))
+    assert_equal([2,3,2,3], eval("13.divmod(5) => a,b => c, d; [a, b, c, d]"))
+    assert_equal(3, eval("1+2 => a"))
+  end
+end
+RUBY


### PR DESCRIPTION
### What is the purpose of this pull request?

Adds "endless" method definition support.

Closes #31. 

### What changes did you make? (overview)

- [x] Added `EndlessMethod` rewriter
- [x] Fixed `ArgsForward` rewriter to traverse `send` nodes without `...`
- [x] Added fallback to rewrite mode if target version is 2.7+ since Unparser has no support for 2.7 AST yet

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md
