### PR TITLE
Add .rbnextrc support for CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## master
 
+- Use`./.rbnextrc` to define CLI args. ([@palkan][])
+
+You can define CLI options in the configuration file to re-use them between environments or
+simply avoid typing every time:
+
+```yml
+# .rbnextrc
+nextify: |
+  --transpiler-mode=rewrite
+  --edge
+```
+
 - Add `--dry-run` option to CLI. ([@palkan][])
 
 - Raise `SyntaxError` when parsing fails. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -240,7 +240,21 @@ $ ruby-next core_ext -l --name=filter --name=deconstruct
   - StructDeconstruct
 ```
 
-### Integrating into a gem development
+### Configuration file
+
+You can define CLI options in the `.rbnextrc` file located in the root of your project to avoid adding them every time you run `ruby-next`.
+
+Configuration file is a YAML with commands as keys and options as multiline strings:
+
+```yml
+# ./.rbnextrc
+
+nextify: |
+  --transpiler-mode=rewrite
+  --edge
+```
+
+## Integrating into a gem development
 
 We recommend _pre-transpiling_ source code to work with older versions before releasing it.
 

--- a/lib/ruby-next/cli.rb
+++ b/lib/ruby-next/cli.rb
@@ -40,6 +40,8 @@ module RubyNext
 
       args.delete(command)
 
+      args.unshift(*load_args_from_rc(command))
+
       COMMANDS.fetch(command) do
         raise "Unknown command: #{command}. Available commands: #{COMMANDS.keys.join(",")}"
       end.run(args)
@@ -92,6 +94,16 @@ module RubyNext
           end
         end
       end
+    end
+
+    def load_args_from_rc(command)
+      return [] unless File.file?(".rbnextrc")
+
+      require "yaml"
+      command_args = YAML.load_file(".rbnextrc")[command]
+      return [] unless command_args
+
+      command_args.lines.flat_map { |line| line.chomp.split(/\s+/) }
     end
   end
 end

--- a/lib/ruby-next/commands/nextify.rb
+++ b/lib/ruby-next/commands/nextify.rb
@@ -64,6 +64,8 @@ module RubyNext
           end
         end
 
+        optparser.parse!(args)
+
         @lib_path = args[0]
 
         if print_help
@@ -72,11 +74,10 @@ module RubyNext
         end
 
         unless lib_path&.then(&File.method(:exist?))
+          $stdout.puts "Path not found: #{lib_path}"
           $stdout.puts optparser.help
           exit 2
         end
-
-        optparser.parse!(args)
 
         @paths =
           if File.directory?(lib_path)

--- a/spec/support/command_testing.rb
+++ b/spec/support/command_testing.rb
@@ -33,7 +33,7 @@ module CommandTesting
     end
 
     def run_ruby_next(command, **options, &block)
-      run("#{RUBY_RUNNER} bin/ruby-next #{command}", **options, &block)
+      run("#{RUBY_RUNNER} #{File.join(__dir__, "../../bin/ruby-next")} #{command}", **options, &block)
     end
   end
 end


### PR DESCRIPTION
### What is the purpose of this pull request?

Make it possible to define common CLI options in a configuration file.

This is a prerequisite for automatically transpiling code installed from source.

### What changes did you make? (overview)

- [x] CLI prepends arguments loaded from `.rbnextrc` for a particular command if any
- [x] Allow calling `nextify` with target dir specified after options (i.e., `ruby-next nextify --edge ./lib`).

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md
