### PR TITLE
Auto-transpile gems installed from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Try to auto-transpile the source code on load in `.setup_gem_load_path` if transpiled files are missing. ([@palkan][])
+
+This would make it possible to install gems from source if transpiled files do not exist in the repository.
+
 - Use`./.rbnextrc` to define CLI args. ([@palkan][])
 
 You can define CLI options in the configuration file to re-use them between environments or

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ $ ruby-next core_ext -l --name=filter --name=deconstruct
   - StructDeconstruct
 ```
 
-### Configuration file
+### CLI configuration file
 
 You can define CLI options in the `.rbnextrc` file located in the root of your project to avoid adding them every time you run `ruby-next`.
 
@@ -290,6 +290,24 @@ due to the way feature resolving works in Ruby (scanning the `$LOAD_PATH` and ha
 If you're using [runtime mode](#runtime-usage) a long with `setup_gem_load_path` (e.g., in tests), the transpiled files are ignored (i.e., we do not modify `$LOAD_PATH`).
 
 \* Ruby Next avoids storing duplicates; instead, only the code for the earlier version is created and is assumed to be used with other versions. For example, if the transpiled code is the same for Ruby 2.5 and Ruby 2.6, only the `.rbnext/2.7/path/to/file.rb` is kept. That's why multiple entries are added to the `$LOAD_PATH` (`.rbnext/2.6` and `.rbnext/2.7` in the specified order for Ruby 2.5 and only `.rbnext/2.7` for Ruby 2.6).
+
+### Transpiled files vs. VSC vs. installing from source
+
+It's a best practice to not keep generated files in repositories. In case of Ruby Next, it's a `lib/.rbnext` folder.
+
+We recommend adding this folder only to the gem package (i.e., it should be added to your `spec.files`) and ignore it in your VSC (e.g., `echo ".rbnext/" >> .gitignore`). That would make transpiled files available in releases without polluting your repository.
+
+What if someone decides to install your gem from the VSC source? They would likely face some syntax errors due to the missing transpiled files.
+
+To solve this problem, Ruby Next _tries_ to transpile the source code when you call `#setup_gem_load_path`. It does this by calling `bundle exec ruby-next nextify <lib_dir> -o <next_dir>`. We make the following assumptions:
+
+- We in the Bundler context (since that's the most common way of installing gems from source).
+- Our Gemfile contains `ruby-next` gem.
+- We use [`.rbnextrc`](#CLI-configuration-file) for transpiling options.
+
+If the command fails we warn the end user.
+
+This feature, _auto-transpiling_, is **disabled** by default (will likely be enabled in future versions). You can enable it by calling `RubyNext::Language.setup_gem_load_path(transpile: true)`.
 
 ## Runtime usage
 

--- a/lib/ruby-next/language/setup.rb
+++ b/lib/ruby-next/language/setup.rb
@@ -5,6 +5,21 @@ require "ruby-next"
 
 module RubyNext
   module Language
+    # Module responsible for transpiling a library at load time
+    module GemTranspiler
+      def self.maybe_transpile(root_dir, lib_dir, target_dir)
+        return if File.directory?(target_dir)
+
+        Dir.chdir(root_dir) do
+          unless system("bundle exec ruby-next nextify ./#{lib_dir} -o #{target_dir} > /dev/null 2>&1")
+            RubyNext.warn "Traspiled files are missing in: #{target_dir}. \n" \
+              "Make sure you have gem 'ruby-next' in your Gemfile to auto-transpile the required files from source on load. " \
+              "Otherwise the code from #{root_dir} may not work correctly."
+          end
+        end
+      end
+    end
+
     class << self
       unless method_defined?(:runtime?)
         def runtime?
@@ -12,7 +27,7 @@ module RubyNext
         end
       end
 
-      def setup_gem_load_path(lib_dir = "lib", rbnext_dir: RUBY_NEXT_DIR)
+      def setup_gem_load_path(lib_dir = "lib", rbnext_dir: RUBY_NEXT_DIR, transpile: false)
         called_from = caller_locations(1, 1).first.path
         dirname = File.dirname(called_from)
 
@@ -29,6 +44,10 @@ module RubyNext
 
         return if Language.runtime? && Language.watch_dirs.include?(dirname)
 
+        next_dirname = File.join(dirname, rbnext_dir)
+
+        GemTranspiler.maybe_transpile(File.dirname(dirname), lib_dir, next_dirname) if transpile
+
         current_index = $LOAD_PATH.index(dirname)
 
         raise "Gem's lib is not in the $LOAD_PATH: #{dirname}" if current_index.nil?
@@ -38,7 +57,7 @@ module RubyNext
         loop do
           break unless version
 
-          version_dir = File.join(dirname, rbnext_dir, version.segments[0..1].join("."))
+          version_dir = File.join(next_dirname, version.segments[0..1].join("."))
 
           if File.exist?(version_dir)
             $LOAD_PATH.insert current_index, version_dir

--- a/spec/integration/fixtures/.rbnextrc
+++ b/spec/integration/fixtures/.rbnextrc
@@ -1,0 +1,2 @@
+nextify: |
+  --transpile-mode=rewrite

--- a/spec/integration/fixtures/lib/txen_source.rb
+++ b/spec/integration/fixtures/lib/txen_source.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "ruby-next/language/setup"
+
+RubyNext::Language.setup_gem_load_path(rbnext_dir: ".rbnext_test", transpile: true)
+
+require "txen/version"
+require "txen/cards"
+require "txen/game"
+
+module Txen
+  def self.call(*cards)
+    cards.inject(0) do |acc, card|
+      acc += Cards.call(card)
+      return :failed if Game.failed?(acc)
+      acc
+    end
+    :ok
+  end
+end

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -5,6 +5,11 @@ require_relative "../support/command_testing"
 using CommandTesting
 
 describe "setup load path" do
+  after do
+    FileUtils.rm_rf(File.join(__dir__, "fixtures", "lib", ".rbnext_test")) if
+      File.directory?(File.join(__dir__, "fixtures", "lib", ".rbnext_test"))
+  end
+
   it "loads correct file versions" do
     skip if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
     run_ruby(
@@ -23,6 +28,22 @@ describe "setup load path" do
       "-e 'puts [Txen.call(\"ace\", \"ace\"), Txen.call(\"ace\", \"4\", \"5\")].join(\";\")'"
     ) do |_status, output, _err|
       output.should include("ok;ok")
+    end
+  end
+
+  it "autotranspiles files is rbnext_dir is missing" do
+    run_ruby(
+      "-I#{File.join(__dir__, "fixtures", "lib")} " \
+      "-r txen_source " \
+      "-e 'puts [Txen.call(\"ace\", \"ace\"), Txen.call(\"ace\", \"4\", \"5\")].join(\";\")'"
+    ) do |_status, output, _err|
+      output.should include("ok;ok")
+      File.directory?(File.join(__dir__, "fixtures", "lib", ".rbnext_test")).should equal true
+      # .rbnextrc is preserved
+      File.exist?(File.join(__dir__, "fixtures", "lib", ".rbnext_test", "2.7", "txen", "cards.rb")).should equal true
+      File.read(File.join(__dir__, "fixtures", "lib", ".rbnext_test", "2.7", "txen", "cards.rb")).lines.size.should equal(
+        File.read(File.join(__dir__, "fixtures", "lib", "txen", "cards.rb")).lines.size
+      )
     end
   end
 end


### PR DESCRIPTION
### What is the purpose of this pull request?

Make it possible to install gems using Ruby Next from source transparently for end users.

### What changes did you make? (overview)

- [x] Added `transpile: true` option to `.setup_gem_load_path` to auto-transpile the source code

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md
