### PR TITLE
Add Ruby 2.4 support

### DIFF
--- a/.github/workflows/ruby-eol-test.yml
+++ b/.github/workflows/ruby-eol-test.yml
@@ -1,0 +1,48 @@
+name: Build EOL
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  ruby-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.4]
+        core_ext: ["gem", "generated"]
+    env:
+      CORE_EXT: ${{ matrix.core_ext }}
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
+      CI: true
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v1
+      with:
+        path: /home/runner/bundle
+        key: bundle-${{ matrix.ruby }}-${{ hashFiles('../Gemfile') }}-${{ hashFiles('**/*.gemspec') }}
+        restore-keys: |
+          bundle-${{ matrix.ruby }}-
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Download MSpec
+      run: |
+        git clone --branch v1.7.0 https://github.com/ruby/mspec.git mspec
+    - name: Bundle install
+      run: |
+        bundle config path /home/runner/bundle
+        bundle install
+        bundle update
+    - name: Run MSpec
+      run: |
+        bundle install --jobs 4 --retry 3
+        bundle exec mspec/bin/mspec
+    - name: Run language specs with source rewriting
+      env:
+        RUBY_NEXT_TRANSPILE_MODE: "rewrite"
+      run: bundle exec mspec/bin/mspec :language

--- a/.github/workflows/ruby-eol-test.yml
+++ b/.github/workflows/ruby-eol-test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.4]
-        core_ext: ["gem", "generated"]
+        core_ext: ["backports"]
     env:
       CORE_EXT: ${{ matrix.core_ext }}
       BUNDLE_JOBS: 4
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: /home/runner/bundle
-        key: bundle-${{ matrix.ruby }}-${{ hashFiles('../Gemfile') }}-${{ hashFiles('**/*.gemspec') }}
+        key: bundle-${{ matrix.ruby }}-${{ hashFiles('../gemfiles/eol.gemfile') }}-${{ hashFiles('**/*.gemspec') }}
         restore-keys: |
           bundle-${{ matrix.ruby }}-
     - uses: ruby/setup-ruby@v1
@@ -36,6 +36,7 @@ jobs:
     - name: Bundle install
       run: |
         bundle config path /home/runner/bundle
+        bundle config --global gemfile gemfiles/eol.gemfile
         bundle install
         bundle update
     - name: Run MSpec

--- a/.github/workflows/ruby-eol-test.yml
+++ b/.github/workflows/ruby-eol-test.yml
@@ -13,9 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.4]
-        core_ext: ["backports"]
     env:
-      CORE_EXT: ${{ matrix.core_ext }}
+      CORE_EXT: backports
+      RUBY_NEXT_CORE_STRATEGY: backports
       BUNDLE_JOBS: 4
       BUNDLE_RETRY: 3
       CI: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-- Add Ruby 2.4 support. ([@palkan])
+- Add Ruby 2.4 support. ([@palkan][])
 
 APIs for <2.5 must be backported via [backports][] gem. Refinements are not supported.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Add Ruby 2.4 support. ([@palkan])
+
+APIs for <2.5 must be backported via [backports][] gem. Refinements are not supported.
+
 ## 0.8.0 (2020-05-01) 🚩
 
 - Add right-hand assignment support. ([@palkan][])
@@ -178,3 +182,4 @@ p a #=> 1
 - Add `Kernel#then`. ([@palkan][])
 
 [@palkan]: https://github.com/palkan
+[backports]: https://github.com/marcandre/backports

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ _Please, submit a PR to add your project to the list!_
   - [`ruby -ruby-next`](#uby-next)
   - [Logging & Debugging](#logging-and-debugging)
 - [RuboCop](#rubocop)
+- [Using with EOL Rubies](#using-with-eol-rubies)
 - [Proposed & edge features](#proposed-and-edge-features)
 
 ## Overview
@@ -65,8 +66,9 @@ Core provides **polyfills** for Ruby core classes APIs via Refinements (default 
 Language is responsible for **transpiling** edge Ruby syntax into older versions. It could be done
 programmatically or via CLI. It also could be done in runtime.
 
-Currently, Ruby Next supports Ruby versions 2.5+ (including JRuby 9.2.8+).
-Please, [open an issue](https://github.com/ruby-next/ruby-next/issues/new/choose) if you would like us to support older Ruby versions.
+Currently, Ruby Next supports Ruby versions 2.4+ (including JRuby 9.2.8+). Support for EOL versions (<2.5) slightly differs though ([see below](#using-with-eol-rubies)).
+
+Please, [open an issue](https://github.com/ruby-next/ruby-next/issues/new/choose) or join the discussion in the existing ones if you would like us to support older Ruby versions.
 
 ## Quick start
 
@@ -422,6 +424,38 @@ AllCops:
 
 **NOTE:** you need `ruby-next` gem available in the environment where you run RuboCop (having `ruby-next-core` is not enough).
 
+## Using with EOL Rubies
+
+We currently provide experimental support for Ruby 2.4. Work on older Rubies (down to 2.2) is in progress.
+
+Ruby Next itself relies on 2.5 features and contains polyfills only for version 2.5+ (and that won't change).
+Thus, to make it work with <2.5 we need to backport some APIs ourselves.
+
+The recommended way of doing this is to use [backports][] gem. You need to load backports **before Ruby Next**.
+
+When using runtime features, you should do the following:
+
+```ruby
+# first, require backports upto 2.5
+require "backports/2.5"
+# then, load Ruby Next
+require "ruby-next"
+# if you need 2.6+ APIs, add Ruby Next core_ext
+require "ruby-next/core_ext"
+# then, load runtime transpiling
+require "ruby-next/language/runtime"
+# or
+require "ruby-next/language/bootsnap"
+```
+
+To load backports while using `ruby-next nextify` command, you must configure the environment variable:
+
+```sh
+RUBY_NEXT_CORE_STRATEGY=backports ruby-next nextify lib/
+```
+
+**NOTE:** Make sure you have `backports` gem installed globally or added to your bundle (if you're using `bundle exec ruby-next ...`).
+
 ## Proposed and edge features
 
 Ruby Next aims to bring edge and proposed features to Ruby community before they (hopefully) reach an official Ruby release.
@@ -486,3 +520,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 [next_parser]: https://github.com/ruby-next/parser
 [Bootsnap]: https://github.com/Shopify/bootsnap
 [rubocop]: https://github.com/rubocop-hq/rubocop
+[backports]: https://github.com/marcandre/backports

--- a/default.mspec
+++ b/default.mspec
@@ -41,7 +41,7 @@ elsif ENV["CORE_EXT"] == "generated"
   RubyNext::Core.strategy = :core_ext
 elsif ENV["CORE_EXT"] == "backports"
   require "ruby-next/core_ext"
-  RubyNext::Core.strategy = :core_ext
+  RubyNext::Core.strategy = :backports
 else
   require "ruby-next/core/runtime"
 end

--- a/default.mspec
+++ b/default.mspec
@@ -29,6 +29,7 @@ end
 ENV["RUBY_NEXT_EDGE"] = "1"
 ENV["RUBY_NEXT_PROPOSED"] = "1"
 
+require "backports/2.5" if ENV["CORE_EXT"] == "backports"
 require "ruby-next/language/runtime"
 
 if ENV["CORE_EXT"] == "gem"
@@ -37,6 +38,9 @@ elsif ENV["CORE_EXT"] == "generated"
   require "ruby-next/cli"
   RubyNext::CLI.new.run(["core_ext", "--min-version", RUBY_VERSION, "-o", File.join(__dir__, "tmp", "core_ext.rb")])
   require_relative "tmp/core_ext"
+  RubyNext::Core.strategy = :core_ext
+elsif ENV["CORE_EXT"] == "backports"
+  require "ruby-next/core_ext"
   RubyNext::Core.strategy = :core_ext
 else
   require "ruby-next/core/runtime"

--- a/gemfiles/eol.gemfile
+++ b/gemfiles/eol.gemfile
@@ -1,0 +1,16 @@
+# Gemfile to run tests for EOL Rubies
+source "https://rubygems.org"
+
+gemspec path: "..", name: "ruby-next-core"
+
+eval_gemfile "rubocop.gemfile"
+
+gem "pry-byebug", platform: :mri
+
+# Backport APIs
+# See https://github.com/marcandre/backports/pull/148
+gem "backports", github: "ruby-next/backports"
+
+# For compatibility tests
+gem "zeitwerk", platform: :mri
+gem "bootsnap", platform: :mri

--- a/lib/ruby-next.rb
+++ b/lib/ruby-next.rb
@@ -34,5 +34,6 @@ module RubyNext
   end
 
   require_relative "ruby-next/core"
+  require_relative "ruby-next/core_ext" if RubyNext::Core.core_ext?
   require_relative "ruby-next/logging"
 end

--- a/lib/ruby-next/core.rb
+++ b/lib/ruby-next/core.rb
@@ -95,7 +95,7 @@ module RubyNext
     end
 
     class << self
-      STRATEGIES = %i[refine core_ext].freeze
+      STRATEGIES = %i[refine core_ext backports].freeze
 
       attr_reader :strategy
 
@@ -109,7 +109,11 @@ module RubyNext
       end
 
       def core_ext?
-        strategy == :core_ext
+        strategy == :core_ext || strategy == :backports
+      end
+
+      def backports?
+        strategy == :backports
       end
 
       def patch(*args, **kwargs, &block)
@@ -135,6 +139,8 @@ module RubyNext
     self.strategy = ENV.fetch("RUBY_NEXT_CORE_STRATEGY", "refine").to_sym
   end
 end
+
+require "backports/2.5" if RubyNext::Core.backports?
 
 require_relative "core/kernel/then"
 

--- a/lib/ruby-next/core_ext.rb
+++ b/lib/ruby-next/core_ext.rb
@@ -15,4 +15,4 @@ RubyNext::Core.patches.extensions.each do |mod, patches|
   end
 end
 
-RubyNext::Core.strategy = :core_ext
+RubyNext::Core.strategy = :core_ext unless RubyNext::Core.core_ext?

--- a/ruby-next-core.gemspec
+++ b/ruby-next-core.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
 
   s.files = Dir.glob("lib/**/*") + Dir.glob("bin/**/*") + %w[README.md LICENSE.txt CHANGELOG.md]
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.4.0"
 
   s.require_paths = ["lib"]
 

--- a/ruby-next.gemspec
+++ b/ruby-next.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
 
   s.files = %w[README.md LICENSE.txt CHANGELOG.md]
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.4.0"
 
   s.require_paths = ["lib"]
 

--- a/spec/cli/core_ext_spec.rb
+++ b/spec/cli/core_ext_spec.rb
@@ -3,8 +3,6 @@
 require_relative "../support/command_testing"
 require "fileutils"
 
-using CommandTesting
-
 describe "ruby-next core_ext" do
   before do
     @out_path = File.join(__dir__, "dummy", "core_ext.rb")

--- a/spec/cli/nextify_spec.rb
+++ b/spec/cli/nextify_spec.rb
@@ -3,8 +3,6 @@
 require_relative "../support/command_testing"
 require "fileutils"
 
-using CommandTesting
-
 describe "ruby-next nextify" do
   after do
     FileUtils.rm_rf(File.join(__dir__, "dummy", ".rbnext"))

--- a/spec/core/enumerator/ruby_produce_spec.rb
+++ b/spec/core/enumerator/ruby_produce_spec.rb
@@ -30,7 +30,7 @@ describe "Enumerator.produce" do
 
   it "with initial keyword arguments" do
     # https://github.com/jruby/jruby/issues/6036
-    skip if defined?(JRUBY_VERSION)
+    next skip if defined?(JRUBY_VERSION)
     passed_args = []
     enum = Enumerator.produce(a: 1, b: 1) { |obj| passed_args << obj; obj.shift if obj.respond_to?(:shift)}
     assert_instance_of(Enumerator, enum)

--- a/spec/core/symbol/start_with_spec.rb
+++ b/spec/core/symbol/start_with_spec.rb
@@ -34,7 +34,7 @@ describe "Sybmol#start_with?" do
 
   it "supports regexps" do
     # TODO: backport is missing
-    skip if RubyNext::Core.backports?
+    next skip if RubyNext::Core.backports?
     regexp = /[h1]/
     :hello.start_with?(regexp).should == true
   end

--- a/spec/core/symbol/start_with_spec.rb
+++ b/spec/core/symbol/start_with_spec.rb
@@ -33,6 +33,8 @@ describe "Sybmol#start_with?" do
   end
 
   it "supports regexps" do
+    # TODO: backport is missing
+    skip if RubyNext::Core.backports?
     regexp = /[h1]/
     :hello.start_with?(regexp).should == true
   end

--- a/spec/core/time/ceil_spec.rb
+++ b/spec/core/time/ceil_spec.rb
@@ -31,18 +31,18 @@ ruby_version_is "2.7" do
     end
 
     it "ceils to 4 decimal places with an explicit argument" do
-      skip if defined?(JRUBY_VERSION)
+      next skip if defined?(JRUBY_VERSION)
       @time.ceil(4).should == Time.utc(2010, 3, 30, 5, 43, "25.0124".to_r)
     end
 
     it "ceils to 7 decimal places with an explicit argument" do
-      skip if defined?(JRUBY_VERSION)
+      next skip if defined?(JRUBY_VERSION)
       @time.ceil(7).should == Time.utc(2010, 3, 30, 5, 43, "25.0123457".to_r)
     end
 
     it "returns an instance of Time, even if #ceil is called on a subclass" do
       # JRuby returns subclass; probably, related to https://github.com/jruby/jruby/issues/5125
-      skip if defined?(JRUBY_VERSION)
+      next skip if defined?(JRUBY_VERSION)
       subclass = Class.new(Time)
       instance = subclass.at(0)
       instance.class.should equal subclass

--- a/spec/core/time/floor_spec.rb
+++ b/spec/core/time/floor_spec.rb
@@ -27,13 +27,13 @@ ruby_version_is "2.7" do
     end
 
     it "floors to 7 decimal places with an explicit argument" do
-      skip if defined?(JRUBY_VERSION)
+      next skip if defined?(JRUBY_VERSION)
       @time.floor(7).should == Time.utc(2010, 3, 30, 5, 43, "25.1234567".to_r)
     end
 
     it "returns an instance of Time, even if #floor is called on a subclass" do
       # JRuby returns subclass; probably, related to https://github.com/jruby/jruby/issues/5125
-      skip if defined?(JRUBY_VERSION)
+      next skip if defined?(JRUBY_VERSION)
       subclass = Class.new(Time)
       instance = subclass.at(0)
       instance.class.should equal subclass

--- a/spec/integration/backtrace_spec.rb
+++ b/spec/integration/backtrace_spec.rb
@@ -2,8 +2,6 @@
 
 require_relative "../support/command_testing"
 
-using CommandTesting
-
 describe "patch has source location meta" do
   it "works" do
     skip if RUBY_VERSION >= "2.7"

--- a/spec/integration/backtrace_spec.rb
+++ b/spec/integration/backtrace_spec.rb
@@ -4,7 +4,7 @@ require_relative "../support/command_testing"
 
 describe "patch has source location meta" do
   it "works" do
-    skip if RUBY_VERSION >= "2.7"
+    next skip if RUBY_VERSION >= "2.7"
 
     source_path = Pathname.new(File.join(__dir__, "../../lib/ruby-next/core/enumerator/produce.rb")).realpath
     source_line = File.open(source_path).each_line.with_index { |line, i| break i + 1 if /wrong number of arguments/.match?(line) }

--- a/spec/integration/bootsnap_spec.rb
+++ b/spec/integration/bootsnap_spec.rb
@@ -4,7 +4,7 @@ require_relative "../support/command_testing"
 
 describe "bootsnap compatibility" do
   it "works" do
-    skip if defined? JRUBY_VERSION
+    next skip if defined? JRUBY_VERSION
 
     cache_path = File.join(__dir__, "fixtures", "bootsnap", "tmp")
     if File.directory?(cache_path)

--- a/spec/integration/bootsnap_spec.rb
+++ b/spec/integration/bootsnap_spec.rb
@@ -2,8 +2,6 @@
 
 require_relative "../support/command_testing"
 
-using CommandTesting
-
 describe "bootsnap compatibility" do
   it "works" do
     skip if defined? JRUBY_VERSION

--- a/spec/integration/edge_proposed_spec.rb
+++ b/spec/integration/edge_proposed_spec.rb
@@ -2,8 +2,6 @@
 
 require_relative "../support/command_testing"
 
-using CommandTesting
-
 describe "edge/proposed features via require" do
   it "proposed features" do
     cmd = <<~CMD
@@ -12,7 +10,7 @@ describe "edge/proposed features via require" do
     CMD
 
     # Set env var to 0 to make sure we do not shadow it
-    run(cmd, env: {"RUBY_NEXT_PROPOSED" => "0"}) do |_status, output, _err|
+    run_command(cmd, env: {"RUBY_NEXT_PROPOSED" => "0"}) do |_status, output, _err|
       output.should include("\"status: \"\n")
       output.should include("\"status: ok\"\n")
     end
@@ -25,7 +23,7 @@ describe "edge/proposed features via require" do
     CMD
 
     # Set env var to 0 to make sure we do not shadow it
-    run(cmd, env: {"RUBY_NEXT_EDGE" => "0"}) do |_status, output, _err|
+    run_command(cmd, env: {"RUBY_NEXT_EDGE" => "0"}) do |_status, output, _err|
       output.should include("human\n")
       output.should include("alien\n")
     end

--- a/spec/integration/language_spec.rb
+++ b/spec/integration/language_spec.rb
@@ -2,8 +2,6 @@
 
 require_relative "../support/command_testing"
 
-using CommandTesting
-
 describe "language features (via -ruby-next)" do
   it "nested array pattern matching" do
     run_ruby(
@@ -28,7 +26,7 @@ describe "language features (via -ruby-next)" do
   end
 
   it "array in hash in pattern matching" do
-    run(
+    run_command(
       "ruby -rbundler/setup -rjson -I#{File.join(__dir__, "../../lib")} -ruby-next #{File.join(__dir__, "fixtures", "array_in_hash_pattern.rb")} " \
       "'{\"name\":\"Alice\",\"children\":[{\"name\":\"Bob\",\"age\":30}]}'"
     ) do |_status, output, _err|

--- a/spec/integration/lexical_scope_spec.rb
+++ b/spec/integration/lexical_scope_spec.rb
@@ -2,8 +2,6 @@
 
 require_relative "../support/command_testing"
 
-using CommandTesting
-
 describe "runtime preserves lexical scope" do
   it "works" do
     run_ruby(

--- a/spec/integration/monkey_patch_spec.rb
+++ b/spec/integration/monkey_patch_spec.rb
@@ -2,8 +2,6 @@
 
 require_relative "../support/command_testing"
 
-using CommandTesting
-
 describe "refinements ignore monkey-patching" do
   it "works" do
     run_ruby(

--- a/spec/integration/nextify_spec.rb
+++ b/spec/integration/nextify_spec.rb
@@ -16,7 +16,7 @@ describe "ruby-next nextify" do
     version_dir = RubyNext.next_version&.then { |v| v.segments[0..1].join(".") }
 
     if version_dir.nil? || !File.exist?(File.join(__dir__, "fixtures", ".rbnext", version_dir))
-      version_dir = Dir.children(File.join(__dir__, "fixtures", ".rbnext")).first
+      version_dir = Dir.children(File.join(__dir__, "fixtures", ".rbnext")).sort.first # rubocop:disable Style/RedundantSort
     end
 
     run_ruby(

--- a/spec/integration/nextify_spec.rb
+++ b/spec/integration/nextify_spec.rb
@@ -3,8 +3,6 @@
 require_relative "../support/command_testing"
 require "fileutils"
 
-using CommandTesting
-
 describe "ruby-next nextify" do
   after do
     FileUtils.rm_rf(File.join(__dir__, "fixtures", ".rbnext"))

--- a/spec/integration/resolve_feature_path_spec.rb
+++ b/spec/integration/resolve_feature_path_spec.rb
@@ -2,8 +2,6 @@
 
 require_relative "../support/command_testing"
 
-using CommandTesting
-
 describe "$LOAD_PATH.resolve_feature_path" do
   it "catches unresolvable features" do
     run_ruby(

--- a/spec/integration/rewrite_spec.rb
+++ b/spec/integration/rewrite_spec.rb
@@ -2,8 +2,6 @@
 
 require_relative "../support/command_testing"
 
-using CommandTesting
-
 describe "rewrite mode" do
   it "preserves lines" do
     run_ruby_next(

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -2,8 +2,6 @@
 
 require_relative "../support/command_testing"
 
-using CommandTesting
-
 describe "setup load path" do
   after do
     FileUtils.rm_rf(File.join(__dir__, "fixtures", "lib", ".rbnext_test")) if

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -9,7 +9,7 @@ describe "setup load path" do
   end
 
   it "loads correct file versions" do
-    skip if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.8")
+    next skip if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.8")
     run_ruby(
       "-I#{File.join(__dir__, "fixtures", "lib")} " \
       "-r txen " \

--- a/spec/integration/uby_next_spec.rb
+++ b/spec/integration/uby_next_spec.rb
@@ -2,8 +2,6 @@
 
 require_relative "../support/command_testing"
 
-using CommandTesting
-
 describe "ruby -ruby-next" do
   it "transform code in runtime when it's required" do
     run_ruby(
@@ -29,7 +27,7 @@ describe "ruby -ruby-next" do
     CMD
 
     # Set env var to 0 to make sure we do not shadow it
-    run(cmd, env: {"RUBY_NEXT_PROPOSED" => "0"}) do |_status, output, _err|
+    run_command(cmd, env: {"RUBY_NEXT_PROPOSED" => "0"}) do |_status, output, _err|
       output.should include("\"status: \"\n")
       output.should include("\"status: ok\"\n")
     end
@@ -42,7 +40,7 @@ describe "ruby -ruby-next" do
     CMD
 
     # Set env var to 0 to make sure we do not shadow it
-    run(cmd, env: {"RUBY_NEXT_EDGE" => "0"}) do |_status, output, _err|
+    run_command(cmd, env: {"RUBY_NEXT_EDGE" => "0"}) do |_status, output, _err|
       output.should include("human\n")
       output.should include("alien\n")
     end

--- a/spec/integration/zeitwerk_spec.rb
+++ b/spec/integration/zeitwerk_spec.rb
@@ -2,8 +2,6 @@
 
 require_relative "../support/command_testing"
 
-using CommandTesting
-
 describe "zeitwerk compatibility" do
   it "works" do
     # Zeitwerk doesn't support JRuby

--- a/spec/language/custom_endless_def_spec.rb
+++ b/spec/language/custom_endless_def_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_unit_to_mspec'
-
-using TestUnitToMspec
+require_relative '../spec_helper'
 
 describe "custom tests for endless method" do
   class CustomEndlessDefSpec

--- a/spec/language/eval_spec.rb
+++ b/spec/language/eval_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../spec_helper'
 using RubyNext::Language::Eval
 
 describe "transforming eval contents" do
@@ -19,8 +20,8 @@ describe "transforming eval contents" do
   end
 
   it "Kernel.eval without binding" do
-    skip unless RubyNext::Language::Rewriters::PatternMatching.unsupported_syntax?
-    skip if RubyNext::Core.core_ext?
+    next skip unless RubyNext::Language::Rewriters::PatternMatching.unsupported_syntax?
+    next skip if RubyNext::Core.core_ext?
 
     eval(%q{
       case {status: :ok}

--- a/spec/language/numbered_parameters_spec.rb
+++ b/spec/language/numbered_parameters_spec.rb
@@ -46,7 +46,7 @@ ruby_version_is "2.7" do
     end
 
     it "warns when numbered parameter is overriten with local variable" do
-      skip
+      next skip
       -> {
         eval("_1 = 0")
       }.should complain(/warning: `_1' is reserved for numbered parameter; consider another name/)

--- a/spec/language/pattern_matching_spec.rb
+++ b/spec/language/pattern_matching_spec.rb
@@ -50,7 +50,7 @@ ruby_version_is "2.7" do
     end
 
     it "warns about pattern matching is experimental feature" do
-      skip
+      next skip
       -> {
         eval(<<~RUBY, binding)
           case 0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,3 +7,18 @@ $VERBOSE = nil
 def ruby_version_is(*)
   yield
 end
+
+# Backports for older mspec
+unless defined?(MSpecEnv)
+  def suppress_warning
+    yield
+  end
+
+  unless defined?(SkippedSpecError)
+    def skip(_ = nil)
+      1.should == 1
+    end
+  end
+
+  require_relative "test_unit_to_mspec"
+end


### PR DESCRIPTION
### What is the purpose of this pull request?

Add support for Ruby 2.4.

Closes #43.

### What changes did you make? (overview)

- [x] Made tests compatible with older MSpec and Ruby (mostly removed refinements 🙂)
- [x] Added `backports` core mode which loads `backports/2.5` automatically.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md
