### PR TITLE
Support passing rewriters to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master
 
+- Support passing rewriters to CLI. ([@sl4vr][])
+
+Use `nextify --list-rewriters` to view all available rewriters.
+Use `nextify` with `--rewrite=REWRITERS...` option to specify which particular rewriters to use.
+
 ## 0.9.1 (2020-06-05)
 
 - Keep `ruby-next` version in sync with `ruby-next-core`. ([@palkan][])
@@ -195,3 +200,4 @@ p a #=> 1
 
 [@palkan]: https://github.com/palkan
 [backports]: https://github.com/marcandre/backports
+[@sl4vr]: https://github.com/sl4vr

--- a/README.md
+++ b/README.md
@@ -200,12 +200,15 @@ It has the following interface:
 ```sh
 $ ruby-next nextify
 Usage: ruby-next nextify DIRECTORY_OR_FILE [options]
-    -o, --output=OUTPUT              Specify output directory or file or stdout (use -o stdout for that)
+    -o, --output=OUTPUT              Specify output directory or file or stdout
         --min-version=VERSION        Specify the minimum Ruby version to support
         --single-version             Only create one version of a file (for the earliest Ruby version)
-        --enable-method-reference    Enable reverted method reference syntax (requires custom parser)
+        --edge                       Enable edge (master) Ruby features
+        --proposed                   Enable proposed/experimental Ruby features
         --transpile-mode=MODE        Transpiler mode (ast or rewrite). Default: ast
         --[no-]refine                Do not inject `using RubyNext`
+        --list-rewriters             List available rewriters
+        --rewrite=REWRITERS...       Specify particular Ruby features to rewrite
     -h, --help                       Print help
     -V                               Turn on verbose mode
         --dry-run                    Print verbose output without generating files

--- a/forspell.dict
+++ b/forspell.dict
@@ -11,6 +11,10 @@ mruby
 polyfills
 pragma
 pre-transpiling
+Rewriter
+Rewriters
+rewriter
+rewriters
 Startless
 Transpile
 transpile

--- a/lib/ruby-next/commands/nextify.rb
+++ b/lib/ruby-next/commands/nextify.rb
@@ -29,7 +29,7 @@ module RubyNext
       def parse!(args)
         print_help = false
         print_rewriters = false
-        specified_rewriter_names = []
+        rewriter_names = []
         @single_version = false
 
         optparser = base_parser do |opts|
@@ -71,7 +71,7 @@ module RubyNext
           end
 
           opts.on("--rewrite=REWRITERS...", "Specify particular Ruby features to rewrite") do |val|
-            specified_rewriter_names << val
+            rewriter_names << val
           end
 
           opts.on("-h", "--help", "Print help") do
@@ -101,20 +101,21 @@ module RubyNext
           exit 2
         end
 
-        if specified_rewriter_names.any?
-          if min_version
-            $stdout.puts "--rewrite cannot be used with --min-version simultaneously"
-            exit 2
-          end
-
-          begin
-            @specified_rewriters = Language.select_rewriters(*specified_rewriter_names)
-          rescue Language::RewriterNotFoundError => error
-            $stdout.puts error.message
-            $stdout.puts "Try --list-rewriters to see list of available rewriters"
-            exit 2
-          end
+        if rewriter_names.any? && min_version
+          $stdout.puts "--rewrite cannot be used with --min-version simultaneously"
+          exit 2
         end
+
+        @specified_rewriters =
+          if rewriter_names.any?
+            begin
+              Language.select_rewriters(*rewriter_names)
+            rescue Language::RewriterNotFoundError => error
+              $stdout.puts error.message
+              $stdout.puts "Try --list-rewriters to see list of available rewriters"
+              exit 2
+            end
+          end
 
         @paths =
           if File.directory?(lib_path)

--- a/lib/ruby-next/commands/nextify.rb
+++ b/lib/ruby-next/commands/nextify.rb
@@ -26,6 +26,7 @@ module RubyNext
 
       def parse!(args)
         print_help = false
+        print_rewriters = false
         @min_version = MIN_SUPPORTED_VERSION
         @single_version = false
 
@@ -63,6 +64,10 @@ module RubyNext
             Core.strategy = :core_ext unless val
           end
 
+          opts.on("--list-rewriters", "List available rewriters") do |val|
+            print_rewriters = true
+          end
+
           opts.on("-h", "--help", "Print help") do
             print_help = true
           end
@@ -74,6 +79,13 @@ module RubyNext
 
         if print_help
           $stdout.puts optparser.help
+          exit 0
+        end
+
+        if print_rewriters
+          Language.rewriters.each do |rewriter|
+            $stdout.puts "#{rewriter::NAME} (\"#{rewriter::SYNTAX_PROBE}\")"
+          end
           exit 0
         end
 

--- a/lib/ruby-next/commands/nextify.rb
+++ b/lib/ruby-next/commands/nextify.rb
@@ -71,12 +71,7 @@ module RubyNext
           end
 
           opts.on("--rewrite=REWRITERS...", "Specify particular Ruby features to rewrite") do |val|
-            # Put endless range in the end, 'cause Parser fails to parse it in pattern matching
-            if val == "endless-range"
-              specified_rewriter_names << val
-            else
-              specified_rewriter_names.unshift(val)
-            end
+            specified_rewriter_names << val
           end
 
           opts.on("-h", "--help", "Print help") do
@@ -112,16 +107,12 @@ module RubyNext
             exit 2
           end
 
-          @specified_rewriters = specified_rewriter_names.map do |rewriter_name|
-            rewriter = Language.rewriters.find { |rewriter| rewriter::NAME == rewriter_name }
-
-            unless rewriter
-              $stdout.puts "Rewriter \"#{rewriter_name}\" not found"
-              $stdout.puts "Try --list-rewriters to see list of available rewriters"
-              exit 2
-            end
-
-            rewriter
+          begin
+            @specified_rewriters = Language.select_rewriters(*specified_rewriter_names)
+          rescue Language::RewriterNotFoundError => error
+            $stdout.puts error.message
+            $stdout.puts "Try --list-rewriters to see list of available rewriters"
+            exit 2
           end
         end
 

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -23,6 +23,8 @@ module RubyNext
     require "ruby-next/language/parser"
     require "ruby-next/language/unparser"
 
+    RewriterNotFoundError = Class.new(StandardError)
+
     class TransformContext
       attr_reader :versions, :use_ruby_next
 
@@ -148,6 +150,16 @@ module RubyNext
       # Rewriters required for the current version
       def current_rewriters
         @current_rewriters ||= rewriters.select(&:unsupported_syntax?)
+      end
+
+      # This method guarantees that rewriters will be returned in order they defined in Language module
+      def select_rewriters(*names)
+        rewriters_delta = names - rewriters.map { |rewriter| rewriter::NAME }
+        if rewriters_delta.any?
+          raise RewriterNotFoundError, "Rewriters not found: #{rewriters_delta.join(",")}"
+        end
+
+        rewriters.select { |rewriter| names.include?(rewriter::NAME) }
       end
 
       private

--- a/lib/ruby-next/language/rewriters/args_forward.rb
+++ b/lib/ruby-next/language/rewriters/args_forward.rb
@@ -4,6 +4,7 @@ module RubyNext
   module Language
     module Rewriters
       class ArgsForward < Base
+        NAME = "args-forward"
         SYNTAX_PROBE = "obj = Object.new; def obj.foo(...) super(...); end"
         MIN_SUPPORTED_VERSION = Gem::Version.new("2.7.0")
 

--- a/lib/ruby-next/language/rewriters/endless_method.rb
+++ b/lib/ruby-next/language/rewriters/endless_method.rb
@@ -4,6 +4,7 @@ module RubyNext
   module Language
     module Rewriters
       class EndlessMethod < Base
+        NAME = "endless-method"
         SYNTAX_PROBE = "obj = Object.new; def obj.foo() = 42"
         MIN_SUPPORTED_VERSION = Gem::Version.new("2.8.0")
 

--- a/lib/ruby-next/language/rewriters/endless_range.rb
+++ b/lib/ruby-next/language/rewriters/endless_range.rb
@@ -4,6 +4,7 @@ module RubyNext
   module Language
     module Rewriters
       class EndlessRange < Base
+        NAME = "endless-range"
         SYNTAX_PROBE = "[0, 1][1..]"
         MIN_SUPPORTED_VERSION = Gem::Version.new("2.6.0")
 

--- a/lib/ruby-next/language/rewriters/method_reference.rb
+++ b/lib/ruby-next/language/rewriters/method_reference.rb
@@ -4,6 +4,7 @@ module RubyNext
   module Language
     module Rewriters
       class MethodReference < Base
+        NAME = "method-reference"
         SYNTAX_PROBE = "Language.:transform"
         MIN_SUPPORTED_VERSION = Gem::Version.new("2.7.0")
 

--- a/lib/ruby-next/language/rewriters/numbered_params.rb
+++ b/lib/ruby-next/language/rewriters/numbered_params.rb
@@ -6,6 +6,7 @@ module RubyNext
       class NumberedParams < Base
         using RubyNext
 
+        NAME = "numbered-params"
         SYNTAX_PROBE = "proc { _1 }.call(1)"
         MIN_SUPPORTED_VERSION = Gem::Version.new("2.7.0")
 

--- a/lib/ruby-next/language/rewriters/pattern_matching.rb
+++ b/lib/ruby-next/language/rewriters/pattern_matching.rb
@@ -216,6 +216,7 @@ module RubyNext
       end
 
       class PatternMatching < Base
+        NAME = "pattern-matching"
         SYNTAX_PROBE = "case 0; in 0; true; else; 1; end"
         MIN_SUPPORTED_VERSION = Gem::Version.new("2.7.0")
 

--- a/lib/ruby-next/language/rewriters/right_hand_assignment.rb
+++ b/lib/ruby-next/language/rewriters/right_hand_assignment.rb
@@ -4,6 +4,7 @@ module RubyNext
   module Language
     module Rewriters
       class RightHandAssignment < Base
+        NAME = "right-hand-assignment"
         SYNTAX_PROBE = "1 + 2 => a"
         MIN_SUPPORTED_VERSION = Gem::Version.new("2.8.0")
 

--- a/spec/cli/dummy/method_reference.rb
+++ b/spec/cli/dummy/method_reference.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Language.:transform

--- a/spec/cli/dummy/right_hand_assignment.rb
+++ b/spec/cli/dummy/right_hand_assignment.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+1 + 2 => a
+a + 1

--- a/spec/cli/nextify_spec.rb
+++ b/spec/cli/nextify_spec.rb
@@ -120,6 +120,71 @@ describe "ruby-next nextify" do
     end
   end
 
+  it "generates one version if --rewrite is provided" do
+    run_ruby_next(
+      "nextify #{File.join(__dir__, "dummy")} " \
+      "--rewrite=endless-range --rewrite=pattern-matching"
+    ) do |_status, _output, err|
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "right_hand_assignment.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "method_reference.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "transpile_me.rb")).should equal true
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "endless_pattern.rb")).should equal true
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "namespaced", "endless_nameless.rb")).should equal true
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "namespaced", "pattern_matching.rb")).should equal true
+    end
+  end
+
+  it "returns error if --rewrite is provided with wrong rewriter" do
+    run_ruby_next(
+      "nextify #{File.join(__dir__, "dummy")} " \
+      "--rewrite=right-hand-assignment",
+      env: {"RUBY_NEXT_EDGE" => "0", "RUBY_NEXT_PROPOSED" => "0"},
+      should_fail: true
+    ) do |_status, output, err|
+      output.should include('Rewriter "right-hand-assignment" not found')
+    end
+  end
+
+  it "generates one version if --rewrite is provided with rewriter from edge along with --edge option" do
+    run_ruby_next(
+      "nextify #{File.join(__dir__, "dummy")} " \
+      "--rewrite=right-hand-assignment --edge",
+      env: {"RUBY_NEXT_EDGE" => "0", "RUBY_NEXT_PROPOSED" => "0"}
+    ) do |_status, _output, err|
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "right_hand_assignment.rb")).should equal true
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "method_reference.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "transpile_me.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "endless_pattern.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "namespaced", "endless_nameless.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "namespaced", "pattern_matching.rb")).should equal false
+    end
+  end
+
+  it "generates one version if --rewrite is provided with rewriter from proposed along with --proposed option" do
+    run_ruby_next(
+      "nextify #{File.join(__dir__, "dummy")} " \
+      "--rewrite=method-reference --proposed",
+      env: {"RUBY_NEXT_EDGE" => "0", "RUBY_NEXT_PROPOSED" => "0"}
+    ) do |_status, _output, err|
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "right_hand_assignment.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "method_reference.rb")).should equal true
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "transpile_me.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "endless_pattern.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "namespaced", "endless_nameless.rb")).should equal false
+      File.exist?(File.join(__dir__, "dummy", ".rbnext", "namespaced", "pattern_matching.rb")).should equal false
+    end
+  end
+
+  it "returns error if --rewrite is provided along with --min-version" do
+    run_ruby_next(
+      "nextify #{File.join(__dir__, "dummy")} " \
+      "--rewrite=endless-range --min-version=2.5",
+      should_fail: true
+    ) do |_status, output, err|
+      output.should include("--rewrite cannot be used with --min-version simultaneously")
+    end
+  end
+
   it "supports --no-refine" do
     run_ruby_next(
       "nextify #{File.join(__dir__, "dummy", "transpile_me.rb")} " \

--- a/spec/cli/nextify_spec.rb
+++ b/spec/cli/nextify_spec.rb
@@ -141,7 +141,7 @@ describe "ruby-next nextify" do
       env: {"RUBY_NEXT_EDGE" => "0", "RUBY_NEXT_PROPOSED" => "0"},
       should_fail: true
     ) do |_status, output, err|
-      output.should include('Rewriter "right-hand-assignment" not found')
+      output.should include("Rewriters not found: right-hand-assignment")
     end
   end
 

--- a/spec/cli/nextify_spec.rb
+++ b/spec/cli/nextify_spec.rb
@@ -216,4 +216,38 @@ describe "ruby-next nextify" do
       end
     end
   end
+
+  it "--list-rewriters" do
+    run_ruby_next(
+      "nextify --list-rewriters",
+      env: {"RUBY_NEXT_PROPOSED" => "0", "RUBY_NEXT_EDGE" => "0"}
+    ) do |_status, output, err|
+      output.should include('args-forward ("obj = Object.new; def obj.foo(...) super(...); end")')
+      output.should include('numbered-params ("proc { _1 }.call(1)")')
+      output.should include('pattern-matching ("case 0; in 0; true; else; 1; end")')
+      output.should include('endless-range ("[0, 1][1..]")')
+      output.should_not include('endless-method ("obj = Object.new; def obj.foo() = 42")')
+      output.should_not include('right-hand-assignment ("1 + 2 => a")')
+      output.should_not include('method-reference ("Language.:transform")')
+    end
+  end
+
+  it "--list-rewriters --edge" do
+    run_ruby_next(
+      "nextify --list-rewriters --edge",
+      env: {"RUBY_NEXT_PROPOSED" => "0", "RUBY_NEXT_EDGE" => "0"}
+    ) do |_status, output, err|
+      output.should include('endless-method ("obj = Object.new; def obj.foo() = 42")')
+      output.should include('right-hand-assignment ("1 + 2 => a")')
+    end
+  end
+
+  it "--list-rewriters --proposed" do
+    run_ruby_next(
+      "nextify --list-rewriters --proposed",
+      env: {"RUBY_NEXT_PROPOSED" => "0", "RUBY_NEXT_EDGE" => "0"}
+    ) do |_status, output, err|
+      output.should include('method-reference ("Language.:transform")')
+    end
+  end
 end


### PR DESCRIPTION
### What is the purpose of this pull request?
Support passing rewriters to CLI - https://github.com/ruby-next/ruby-next/issues/42

### What changes did you make? (overview)
`--list-rewriters` and `--rewrite` options for `nextify` command.

### Is there anything you'd like reviewers to focus on?
I didn't dig into [that](https://github.com/sl4vr/ruby-next/blob/af86786394cb395b5f8c22c260f06a3f50d12c92/lib/ruby-next/commands/nextify.rb#L138-L139), just supposed rewriters gonna rewrite. Also it just failed for me in other case.

Also this implementation requires `--edge` and `--proposed` flags to use and even list corresponding rewriters. If it's not supposed to be so, I can change that.
### Checklist

- [X] I've added tests for this change
- [x] I've added a Changelog entry
- [X] I've updated a documentation/SUPPORTED_FEATURES.md
