### PR TITLE
Add find pattern support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Add find pattern support. ([@palkan][])
+
+Now you can do: `[0, 1, 2] in [*, 1 => a, *c]`.
+
 - Add Ruby 2.2 support. ([@palkan][])
 
 With support for safe navigation operator (`&.`) and squiggly heredocs (`<<~TXT`).

--- a/README.md
+++ b/README.md
@@ -429,6 +429,8 @@ You must set `TargetRubyVersion: next` to make RuboCop use a Ruby Next parser.
 
 Alternatively, you can load the patch from the command line by running: `rubocop -r ruby-next/rubocop ...`.
 
+We recommend using the latest RuboCop version, 'cause it has support for new nodes built-in.
+
 Also, when pre-transpiling source code with `ruby-next nextify`, we suggest ignoring the transpiled files:
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -506,7 +506,9 @@ require "ruby-next/language/runtime"
 
 - "Endless" method definition (`def foo() = 42`) ([#16746](https://bugs.ruby-lang.org/issues/16746)).
 
-- Right-hand assignment (`13.divmod(5) => a,b`) ([#15921](https://bugs.ruby-lang.org/issues/15921))
+- Right-hand assignment (`13.divmod(5) => a,b`) ([#15921](https://bugs.ruby-lang.org/issues/15921)).
+
+- Find pattern (`[0, 1, 2] in [*, 1 => a, *c]`) ([#16828](https://bugs.ruby-lang.org/issues/16828)).
 
 ### Supported proposed features
 

--- a/SUPPORTED_FEATURES.md
+++ b/SUPPORTED_FEATURES.md
@@ -67,3 +67,5 @@ The possible translation depends on the _end_ type which could hardly be inferre
 - "Endless" method definition (`def foo() = 42`) ([#16746](https://bugs.ruby-lang.org/issues/16746))
 
 - Right-hand assignment (`13.divmod(5) => a,b`) ([#15921](https://bugs.ruby-lang.org/issues/15921))
+
+- Find pattern (`[0, 1, 2] in [*, 1 => a, *c]`) ([#16828](https://bugs.ruby-lang.org/issues/16828)).

--- a/gemfiles/rubocop.gemfile
+++ b/gemfiles/rubocop.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org" do
   gem "rubocop-md", "~> 0.3"
-  gem "standard", "~> 0.2.0"
+  gem "standard", "~> 0.5.0"
 
   eval_gemfile "parser.gemfile"
 end

--- a/lib/ruby-next/cli.rb
+++ b/lib/ruby-next/cli.rb
@@ -61,7 +61,7 @@ module RubyNext
     def maybe_print_help
       return unless @print_help
 
-      STDOUT.puts optparser.help
+      $stdout.puts optparser.help
       exit 0
     end
 
@@ -85,7 +85,7 @@ module RubyNext
           opts.banner = "Usage: ruby-next COMMAND [options]"
 
           opts.on("-v", "--version", "Print version") do
-            STDOUT.puts RubyNext::VERSION
+            $stdout.puts RubyNext::VERSION
             exit 0
           end
 

--- a/lib/ruby-next/commands/core_ext.rb
+++ b/lib/ruby-next/commands/core_ext.rb
@@ -160,7 +160,7 @@ module RubyNext
         # remove empty lines
         new_src.gsub!(/^\s+$/, "")
         # remove traling blank lines
-        new_src.gsub!(/\n\z/, "")
+        new_src.delete_suffix!("\n")
         new_src
       end
     end

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -188,6 +188,11 @@ module RubyNext
     require "ruby-next/language/rewriters/pattern_matching"
     rewriters << Rewriters::PatternMatching
 
+    # Must be added after general pattern matching rewriter to become
+    # no-op in Ruby <2.7
+    require "ruby-next/language/rewriters/find_pattern"
+    rewriters << Rewriters::FindPattern
+
     # Put endless range in the end, 'cause Parser fails to parse it in
     # pattern matching
     require "ruby-next/language/rewriters/endless_range"

--- a/lib/ruby-next/language/rewriters/base.rb
+++ b/lib/ruby-next/language/rewriters/base.rb
@@ -34,7 +34,7 @@ module RubyNext
           end
 
           def key?(name)
-            !!fetch(name) { false }
+            !!fetch(name) { false } # rubocop:disable Style/RedundantFetchBlock
           end
 
           def fetch(name)

--- a/lib/ruby-next/language/rewriters/find_pattern.rb
+++ b/lib/ruby-next/language/rewriters/find_pattern.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "ruby-next/language/rewriters/pattern_matching"
+
+module RubyNext
+  module Language
+    module Rewriters
+      using RubyNext
+
+      # Separate pattern matching rewriter for Ruby 2.7 to
+      # transpile only case...in  with a find pattern
+      class FindPattern < PatternMatching
+        NAME = "pattern-matching-find-pattern"
+        SYNTAX_PROBE = "case 0; in [*,0,*]; true; else; 1; end"
+        MIN_SUPPORTED_VERSION = Gem::Version.new("2.8.0")
+
+        def on_case_match(node)
+          @has_find_pattern = false
+          process_regular_node(node).then do |new_node|
+            return new_node unless has_find_pattern
+            super(node)
+          end
+        end
+
+        def on_in_match(node)
+          @has_find_pattern = false
+          process_regular_node(node).then do |new_node|
+            return new_node unless has_find_pattern
+            super(node)
+          end
+        end
+
+        def on_find_pattern(node)
+          @has_find_pattern = true
+          super(node)
+        end
+
+        private
+
+        attr_reader :has_find_pattern
+      end
+    end
+  end
+end

--- a/lib/ruby-next/rubocop.rb
+++ b/lib/ruby-next/rubocop.rb
@@ -52,15 +52,14 @@ module RuboCop
   module AST
     module Traversal
       # Fixed in https://github.com/rubocop-hq/rubocop/pull/7786
-      unless defined?(::RuboCop::AST::CaseMatchNode)
-        %i[case_match in_pattern].each do |type|
-          module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+      %i[case_match in_pattern find_pattern].each do |type|
+        next if method_defined?(:"on_#{type}")
+        module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 def on_#{type}(node)
-  node.children.each { |child| send(:"on_\#{child.type}", child) if child }
-  nil
+node.children.each { |child| send(:"on_\#{child.type}", child) if child }
+nil
 end
-          RUBY
-        end
+        RUBY
       end
     end
   end

--- a/lib/uby-next.rb
+++ b/lib/uby-next.rb
@@ -47,7 +47,7 @@ at_exit do
         next unless command
         command.tr! '\012', "\n"
         command.tr! "\\", "\n"
-        command.match(/\-e(.*)/m)
+        command.match(/-e(.*)/m)
       end.then do |matches|
         next unless matches
 

--- a/spec/integration/fixtures/rewrite.rb
+++ b/spec/integration/fixtures/rewrite.rb
@@ -5,6 +5,7 @@ module Eternal
     case 4
     in (1..)
       true
+    in Array[*, 4, *]
     else
       false
     end => x

--- a/spec/language/ruby_pattern_matching_spec.rb
+++ b/spec/language/ruby_pattern_matching_spec.rb
@@ -15,6 +15,63 @@ eval "\n#{<<-'END_of_GUARD'}", binding, __FILE__, __LINE__
 using TestUnitToMspec
 
 class TestPatternMatching < Test::Unit::TestCase
+  def test_find_pattern
+    [0, 1, 2] in [*, 1 => a, *]
+    assert_equal(1, a)
+
+    [0, 1, 2] in [*a, 1 => b, *c]
+    assert_equal([0], a)
+    assert_equal(1, b)
+    assert_equal([2], c)
+
+    assert_block do
+      case [0, 1, 2]
+      in [*, 9, *]
+        false
+      else
+        true
+      end
+    end
+
+    assert_block do
+      case [0, 1, 2]
+      in [*, Integer, String, *]
+        false
+      else
+        true
+      end
+    end
+
+    [0, 1, 2] in [*a, 1 => b, 2 => c, *d]
+    assert_equal([0], a)
+    assert_equal(1, b)
+    assert_equal(2, c)
+    assert_equal([], d)
+
+    case [0, 1, 2]
+    in *, 1 => a, *;
+        assert_equal(1, a)
+    end
+
+    assert_block do
+      case [0, 1, 2]
+      in String(*, 1, *)
+        false
+      in Array(*, 1, *)
+        true
+      end
+    end
+
+    assert_block do
+      case [0, 1, 2]
+      in String[*, 1, *]
+        false
+      in Array[*, 1, *]
+        true
+      end
+    end
+  end
+
   class C
     class << self
       attr_accessor :keys


### PR DESCRIPTION
### What is the purpose of this pull request?

Closes #48

### What changes did you make? (overview)

- [x] Enhanced PatternMatching rewriter to handle `find_pattern` nodes.

### Is there anything you'd like reviewers to focus on?

The find pattern is transpiled into a `.find` block iterating over indexes:

```ruby
[*a, 1, 2 => c, *] #=>

(a, c = nil) || arr.find.with_index { |_, i| (a = arr.take(i)) && arr[i] == 1 && (arr[i + 1] == 2  && (c = arr[i + 1] || true)) }
```

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md

### TODO

- [x] Fix rewriting: Unparser generates multi-line blocks with `do |_|  ... end`), while we need a single line (`{ |_|  ... }`)