### PR TITLE
Add shorthand kwargs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Extended proposed shorthand Hash syntax to support kwargs as well. ([@palkan][])
+
+You can try it: `x = 1; y = 2; foo(x:, y:) # => foo(x: x, y: y)`.
+
 - **Rewrite mode is used by default in transpiler**. ([@palkan][])
 
 - Move 3.0 features to stable features. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ No new features since 3.0 release.
 
 - _Method reference_ operator (`.:`) ([#13581](https://bugs.ruby-lang.org/issues/13581)).
 
-- Shorthand Hash notation (`data = {x, y}`) ([#15236](https://bugs.ruby-lang.org/issues/15236)).
+- Shorthand Hash/kwarg notation (`data = {x, y}` or `foo(x:, y:)`) ([#15236](https://bugs.ruby-lang.org/issues/15236)).
 
 ## Contributing
 

--- a/SUPPORTED_FEATURES.md
+++ b/SUPPORTED_FEATURES.md
@@ -74,4 +74,4 @@ The possible translation depends on the _end_ type which could hardly be inferre
 
 - **REVERTED IN RUBY ([#16275](https://bugs.ruby-lang.org/issues/16275))** Method reference operator (`Module.:method`) ([#12125](https://bugs.ruby-lang.org/issues/12125), [#13581](https://bugs.ruby-lang.org/issues/13581))
 
-- Shorthand Hash notation (`data = {x, y}`) ([#15236](https://bugs.ruby-lang.org/issues/15236)).
+- Shorthand Hash/kwarg notation (`data = {x, y}` or `foo(x:, y:)`) ([#15236](https://bugs.ruby-lang.org/issues/15236)).

--- a/forspell.dict
+++ b/forspell.dict
@@ -7,6 +7,7 @@ Bootsnap's
 deps
 dirs
 entrypoint
+kwargs
 mruby
 polyfills
 pragma

--- a/ruby-next-core.gemspec
+++ b/ruby-next-core.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.executables = ["ruby-next"]
 
-  s.add_development_dependency "ruby-next-parser", ">= 3.0.0.2"
+  s.add_development_dependency "ruby-next-parser", ">= 3.0.0.3"
   s.add_development_dependency "unparser", ">= 0.4.8", "< 0.6.0"
 end

--- a/ruby-next.gemspec
+++ b/ruby-next.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "ruby-next-core", RubyNext::VERSION
-  s.add_dependency "ruby-next-parser", ">= 3.0.0.2"
+  s.add_dependency "ruby-next-parser", ">= 3.0.0.3"
   s.add_dependency "unparser", ">= 0.4.8", "< 0.6.0"
 end

--- a/spec/integration/fixtures/rubocop/short_hash.rb
+++ b/spec/integration/fixtures/rubocop/short_hash.rb
@@ -3,3 +3,6 @@
 def short_hash(a, b)
   {a, sum: a + b, b}
 end
+
+a = 1
+short_hash(a:)

--- a/spec/language/fixtures/kwarg.rb
+++ b/spec/language/fixtures/kwarg.rb
@@ -1,0 +1,5 @@
+class KwargSpecs
+  def call(*args, **kwargs)
+    [args, kwargs]
+  end
+end

--- a/spec/language/shorthand_hash_spec.rb
+++ b/spec/language/shorthand_hash_spec.rb
@@ -2,7 +2,7 @@ require_relative '../spec_helper'
 
 using RubyNext::Language::Eval
 
-ruby_version_is "2.8" do
+ruby_version_is "3.1" do
   describe "{x}" do
     it "accepts short notation 'key' for 'key: value' syntax" do
       a, b, c = 1, 2, 3

--- a/spec/language/shorthand_kwarg_spec.rb
+++ b/spec/language/shorthand_kwarg_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../spec_helper'
+require_relative 'fixtures/kwarg'
+
+using RubyNext::Language::Eval
+
+ruby_version_is "3.1" do
+  describe "foo(x:)" do
+    it "accepts short notation 'kwarg' in method call" do
+      obj = KwargSpecs.new
+      a, b, c = 1, 2, 3
+      arr, h = eval('obj.call a:', binding)
+      h.should == {a: 1}
+      arr.should == []
+
+      arr, h = eval('obj.call(a:, b:, c:)', binding)
+      h.should == {a: 1, b: 2, c: 3}
+      arr.should == []
+
+      arr, h = eval('obj.call(a:, b: 10, c:)', binding)
+      h.should == {a: 1, b: 10, c: 3}
+      arr.should == []
+    end
+
+    it "handles identifiers" do
+      obj = KwargSpecs.new
+
+      obj.singleton_class.class_eval(<<-RUBY)
+        def bar
+          "baz"
+        end
+
+        def foo(val)
+          call bar:, val:
+        end
+      RUBY
+
+      obj.foo(1).should == [[], {bar: "baz", val: 1}]
+    end
+  end
+end


### PR DESCRIPTION
### What is the purpose of this pull request?

Extend proposed shorthand Hash syntax to support kwargs as wel:

```ruby
x = 1
y = 2
foo(x:, y:) # => foo(x: x, y: y)
```

### What changes did you make? (overview)

Upgraded Parser and added some specs 🙂

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md
