### PR TITLE
Add Array#intersect?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Added `Array#intersect?`. ([@skryukov][])
+
 ## 0.12.0 (2021-01-12)
 
 - Added required keyword arguments rewriter. ([@palkan][])
@@ -281,3 +283,4 @@ p a #=> 1
 [@palkan]: https://github.com/palkan
 [backports]: https://github.com/marcandre/backports
 [@sl4vr]: https://github.com/sl4vr
+[@skryukov]: https://github.com/skryukov

--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ require "ruby-next/language/runtime"
 
 ### Supported edge features
 
-No new features since 3.0 release.
+`Array#intersect?` ([#15198](https://bugs.ruby-lang.org/issues/15198))
 
 ### Supported proposed features
 

--- a/SUPPORTED_FEATURES.md
+++ b/SUPPORTED_FEATURES.md
@@ -70,6 +70,10 @@ The possible translation depends on the _end_ type which could hardly be inferre
 
 - Single-line pattern matching (`{a: 2} in {a:, b:}` or `{a: 2} => {a:, b:}`)
 
+### 3.1
+
+- `Array#intersect?` ([#15198](https://bugs.ruby-lang.org/issues/15198))
+
 ### Proposals
 
 - **REVERTED IN RUBY ([#16275](https://bugs.ruby-lang.org/issues/16275))** Method reference operator (`Module.:method`) ([#12125](https://bugs.ruby-lang.org/issues/12125), [#13581](https://bugs.ruby-lang.org/issues/13581))

--- a/lib/ruby-next/core.rb
+++ b/lib/ruby-next/core.rb
@@ -188,6 +188,8 @@ require "ruby-next/core/struct/deconstruct_keys"
 
 require "ruby-next/core/hash/except"
 
+require "ruby-next/core/array/intersect"
+
 # Generate refinements
 RubyNext.module_eval do
   RubyNext::Core.patches.refined.each do |mod, patches|

--- a/lib/ruby-next/core/array/intersect.rb
+++ b/lib/ruby-next/core/array/intersect.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RubyNext::Core.patch Array, method: :intersect?, version: "3.1" do
+  <<-RUBY
+def intersect?(other)
+  !(self & other).empty? 
+end
+  RUBY
+end

--- a/spec/core/array/intersect_spec.rb
+++ b/spec/core/array/intersect_spec.rb
@@ -1,0 +1,74 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "Array#intersect?" do
+  it "returns if there is intersection" do
+    [].intersect?([]).should == false
+    [1, 2].intersect?([]).should == false
+    [].intersect?([1, 2]).should == false
+    [ 1, 3, 5 ].intersect?([ 1, 2, 3 ]).should == true
+    [ nil ].intersect?([ nil ]).should == true
+  end
+
+  it "does not modify the original Array" do
+    a = [1, 1, 3, 5]
+    a.intersect?([1, 2, 3]).should == true
+    a.should == [1, 1, 3, 5]
+  end
+
+  it "properly handles recursive arrays" do
+    empty = ArraySpecs.empty_recursive_array
+    empty.intersect?(empty).should == true
+
+    ArraySpecs.recursive_array.intersect?([]).should == false
+    [].intersect?(ArraySpecs.recursive_array).should == false
+
+    ArraySpecs.recursive_array.intersect?(ArraySpecs.recursive_array).should == true
+  end
+
+  it "tries to convert the passed argument to an Array using #to_ary" do
+    obj = mock('[1,2,3]')
+    obj.should_receive(:to_ary).and_return([1, 2, 3])
+    [1, 2].intersect?(obj).should == true
+  end
+
+  it "determines equivalence between elements in the sense of eql?" do
+    not_supported_on :opal do
+      [5.0, 4.0].intersect?([5, 4]).should == false
+    end
+
+    str = "x"
+    [str].intersect?([str.dup]).should == true
+
+    obj1 = mock('1')
+    obj2 = mock('2')
+    obj1.stub!(:hash).and_return(0)
+    obj2.stub!(:hash).and_return(0)
+    obj1.should_receive(:eql?).at_least(1).and_return(true)
+    obj2.stub!(:eql?).and_return(true)
+
+    [obj1].intersect?([obj2]).should == true
+    [obj1, obj1, obj2, obj2].intersect?([obj2]).should == true
+
+    obj1 = mock('3')
+    obj2 = mock('4')
+    obj1.stub!(:hash).and_return(0)
+    obj2.stub!(:hash).and_return(0)
+    obj1.should_receive(:eql?).at_least(1).and_return(false)
+
+    [obj1].intersect?([obj2]).should == false
+    [obj1, obj1, obj2, obj2].intersect?([obj2]).should == true
+  end
+
+  it "does not call to_ary on array subclasses" do
+    [5, 6].intersect?(ArraySpecs::ToAryArray[1, 2, 5, 6]).should == true
+  end
+
+  it "properly handles an identical item even when its #eql? isn't reflexive" do
+    x = mock('x')
+    x.stub!(:hash).and_return(42)
+    x.stub!(:eql?).and_return(false) # Stubbed for clarity and latitude in implementation; not actually sent by MRI.
+
+    [x].intersect?([x]).should == true
+  end
+end


### PR DESCRIPTION
This PR adds `Array#intersect?` ([#15198](https://bugs.ruby-lang.org/issues/15198))

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md

Closes #72 