### PR TITLE
Restrict dependencies for v0.13.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,13 +522,13 @@ require "ruby-next/language/runtime"
 
 ### Supported edge features
 
-- `Array#intersect?` ([#15198](https://bugs.ruby-lang.org/issues/15198))
-
-- Shorthand Hash/kwarg notation (`data = {x:, y:}` or `foo(x:, y:)`) ([#15236](https://bugs.ruby-lang.org/issues/15236)).
+`Array#intersect?` ([#15198](https://bugs.ruby-lang.org/issues/15198))
 
 ### Supported proposed features
 
 - _Method reference_ operator (`.:`) ([#13581](https://bugs.ruby-lang.org/issues/13581)).
+
+- Shorthand Hash/kwarg notation (`data = {x, y}` or `foo(x:, y:)`) ([#15236](https://bugs.ruby-lang.org/issues/15236)).
 
 ## Contributing
 

--- a/SUPPORTED_FEATURES.md
+++ b/SUPPORTED_FEATURES.md
@@ -42,12 +42,6 @@
 
 - `Hash#except` ([#15822](https://bugs.ruby-lang.org/issues/15822))
 
-## 3.1
-
-- `Array#intersect?` ([#15198](https://bugs.ruby-lang.org/issues/15198))
-
-- `Enumerable#tally` with the resulting hash ([#17744](https://bugs.ruby-lang.org/issues/17744))
-
 ## Syntax
 
 ### 2.6
@@ -78,8 +72,12 @@ The possible translation depends on the _end_ type which could hardly be inferre
 
 ### 3.1
 
-- Shorthand Hash/kwarg notation (`data = {x:, y:}` or `foo(x:, y:)`) ([#15236](https://bugs.ruby-lang.org/issues/15236)).
+- `Array#intersect?` ([#15198](https://bugs.ruby-lang.org/issues/15198))
+
+- `Enumerable#tally` with the resulting hash ([#17744](https://bugs.ruby-lang.org/issues/17744))
 
 ### Proposals
 
 - **REVERTED IN RUBY ([#16275](https://bugs.ruby-lang.org/issues/16275))** Method reference operator (`Module.:method`) ([#12125](https://bugs.ruby-lang.org/issues/12125), [#13581](https://bugs.ruby-lang.org/issues/13581))
+
+- Shorthand Hash/kwarg notation (`data = {x, y}` or `foo(x:, y:)`) ([#15236](https://bugs.ruby-lang.org/issues/15236)).

--- a/lib/ruby-next/core.rb
+++ b/lib/ruby-next/core.rb
@@ -62,7 +62,7 @@ module RubyNext
         mod_name = singleton? ? singleton.name : mod.name
         camelized_method_name = method_name.to_s.split("_").map(&:capitalize).join
 
-        "#{mod_name}#{camelized_method_name}".gsub(/\W/, "") # rubocop:disable Performance/StringReplacement
+        "#{mod_name}#{camelized_method_name}".gsub(/\W/, "")
       end
 
       def build_location(trace_locations)

--- a/lib/ruby-next/language/rewriters/shorthand_hash.rb
+++ b/lib/ruby-next/language/rewriters/shorthand_hash.rb
@@ -5,15 +5,13 @@ module RubyNext
     module Rewriters
       class ShorthandHash < Base
         NAME = "shorthand-hash"
-        SYNTAX_PROBE = "data = {x:}"
-        MIN_SUPPORTED_VERSION = Gem::Version.new("3.1.0")
+        SYNTAX_PROBE = "data = {x}"
+        MIN_SUPPORTED_VERSION = Gem::Version.new(RubyNext::NEXT_VERSION)
 
-        def on_pair(node)
-          return super(node) unless node.children[0].loc.last_column == node.children[1].loc.last_column
-
+        def on_ipair(node)
           context.track! self
 
-          _, ident, = *node.children
+          ident, = *node.children
 
           key = key_from_ident(ident)
 

--- a/lib/ruby-next/rubocop.rb
+++ b/lib/ruby-next/rubocop.rb
@@ -79,6 +79,10 @@ module RuboCop
         trigger_responding_cops(:on_meth_ref, node)
       end
 
+      def on_ipair(node)
+        trigger_responding_cops(:on_ipair, node)
+      end
+
       unless method_defined?(:on_numblock)
         def on_numblock(node)
           children = node.children

--- a/lib/ruby-next/version.rb
+++ b/lib/ruby-next/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubyNext
-  VERSION = "0.13.2"
+  VERSION = "0.13.3"
 end

--- a/ruby-next-core.gemspec
+++ b/ruby-next-core.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.executables = ["ruby-next"]
 
-  s.add_development_dependency "ruby-next-parser", ">= 3.1.0.0"
+  s.add_development_dependency "ruby-next-parser", ">= 3.0.0.3"
   s.add_development_dependency "unparser", "~> 0.6.0"
 end

--- a/ruby-next-core.gemspec
+++ b/ruby-next-core.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
 
   s.executables = ["ruby-next"]
 
-  s.add_development_dependency "ruby-next-parser", ">= 3.0.0.3"
+  s.add_development_dependency "ruby-next-parser", ">= 3.0.0.3", "< 3.1.0.0"
   s.add_development_dependency "unparser", "~> 0.6.0"
+  s.add_development_dependency "parser", "< 3.0.3.0"
 end

--- a/ruby-next.gemspec
+++ b/ruby-next.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "ruby-next-core", RubyNext::VERSION
-  s.add_dependency "ruby-next-parser", ">= 3.1.0.0"
+  s.add_dependency "ruby-next-parser", ">= 3.0.0.3"
   s.add_dependency "unparser", "~> 0.6.0"
 end

--- a/ruby-next.gemspec
+++ b/ruby-next.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "ruby-next-core", RubyNext::VERSION
-  s.add_dependency "ruby-next-parser", ">= 3.0.0.3"
+  s.add_dependency "ruby-next-parser", ">= 3.0.0.3", "< 3.1.0.0"
   s.add_dependency "unparser", "~> 0.6.0"
+  s.add_dependency "parser", "< 3.0.3.0"
 end

--- a/spec/integration/fixtures/rubocop/short_hash.rb
+++ b/spec/integration/fixtures/rubocop/short_hash.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 def short_hash(a, b)
-  {a:, sum: a + b, b:} # rubocop:disable Layout/SpaceAfterColon
+  {a, sum: a + b, b}
 end
 
 a = 1
-short_hash(a:) # rubocop:disable Layout/SpaceAfterColon
+short_hash(a:)

--- a/spec/language/custom_pattern_matching_spec.rb
+++ b/spec/language/custom_pattern_matching_spec.rb
@@ -144,19 +144,6 @@ describe "custom tests for pattern mathing" do
         end
       end
     end
-
-    it "mixed" do
-      assert_block do
-        case [{a: 1, b: [1]}, {a: 1, c: ["2"]}]
-          in [{a:, c:},]
-            false
-          in [{a: 1, b:}, {a: 1, c: [Integer]}]
-            false
-          in [_, {a: 1, c: [String]}]
-            true
-        end
-      end
-    end
   end
 
   describe "AS pattern" do

--- a/spec/language/shorthand_hash_spec.rb
+++ b/spec/language/shorthand_hash_spec.rb
@@ -3,24 +3,24 @@ require_relative '../spec_helper'
 using RubyNext::Language::Eval
 
 ruby_version_is "3.1" do
-  describe "{x:}" do
+  describe "{x}" do
     it "accepts short notation 'key' for 'key: value' syntax" do
       a, b, c = 1, 2, 3
-      h = eval('{a:}', binding)
+      h = eval('{a}', binding)
       {a: 1}.should == h
-      h = eval('{a:, b:, c:}', binding)
+      h = eval('{a, b, c}', binding)
       {a: 1, b: 2, c: 3}.should == h
     end
 
     it "ignores hanging comma on short notation" do
       a, b, c = 1, 2, 3
-      h = eval('{a:, b:, c:,}', binding)
+      h = eval('{a, b, c,}', binding)
       {a: 1, b: 2, c: 3}.should == h
     end
 
     it "accepts mixed 'key', 'key: value', 'key => value' and '\"key\"': value' syntax" do
       a, e = 1, 5
-      h = eval('{a:, :b => 2, "c" => 3, :d => 4, e:}', binding)
+      h = eval('{a, :b => 2, "c" => 3, :d => 4, e}', binding)
       eval('{a: 1, :b => 2, "c" => 3, "d": 4, e: 5}', binding).should == h
     end
 
@@ -32,7 +32,7 @@ ruby_version_is "3.1" do
         end
 
         def foo(val)
-          {bar:, val:}
+          {bar, val}
         end
       RUBY
 


### PR DESCRIPTION
Ruby Next `0.13.2` has changed the shorthand syntax.
At the same time, release of new parsers has broke Ruby Next `0.13.1`.

To fix this and make it possible for users to freeze `~> 0.13.0` to use old shorthand syntax, I think we need:

- [ ] release Ruby Next `0.14.0` with the changes from `0.13.2` and `master`
- [ ] release Ruby Next `0.13.3` without changes from `0.13.2` and with restricted parser versions

Optionally, we can introduce daily workflows runs (not implemented in this PR).