### PR TITLE
Add binding non-local vars support to pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- [Proposed] Add support for binding instance, class, global variables in pattern matching. ([@palkan][])
+
+This brings back rightward assignment: `42 => @v`.
+
 - Add `MatchData#match`. ([@palkan][])
 
 - Add support for command syntax in endless methods (`def foo() = puts "bar"`)

--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@ require "ruby-next/language/runtime"
 ### Supported proposed features
 
 - _Method reference_ operator (`.:`) ([#13581](https://bugs.ruby-lang.org/issues/13581)).
+- Binding non-local variables in pattern matching (`42 => @v`) ([#18408](https://bugs.ruby-lang.org/issues/18408)).
 
 ## Contributing
 

--- a/SUPPORTED_FEATURES.md
+++ b/SUPPORTED_FEATURES.md
@@ -93,3 +93,5 @@ The possible translation depends on the _end_ type which could hardly be inferre
 ### Proposals
 
 - **REVERTED IN RUBY ([#16275](https://bugs.ruby-lang.org/issues/16275))** Method reference operator (`Module.:method`) ([#12125](https://bugs.ruby-lang.org/issues/12125), [#13581](https://bugs.ruby-lang.org/issues/13581))
+
+- Binding instance, class, global variables in pattern matching (`42 => @v`) ([#18408](https://bugs.ruby-lang.org/issues/18408)).

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -223,6 +223,9 @@ module RubyNext
     require "ruby-next/language/rewriters/endless_method_command"
     rewriters << Rewriters::EndlessMethodCommand
 
+    require "ruby-next/language/rewriters/bind_vars_pattern"
+    rewriters << Rewriters::BindVarsPattern
+
     # Put endless range in the end, 'cause Parser fails to parse it in
     # pattern matching
     require "ruby-next/language/rewriters/endless_range"

--- a/lib/ruby-next/language/rewriters/bind_vars_pattern.rb
+++ b/lib/ruby-next/language/rewriters/bind_vars_pattern.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "ruby-next/language/rewriters/pattern_matching"
+
+module RubyNext
+  module Language
+    module Rewriters
+      using RubyNext
+
+      # Separate pattern matching rewriter for Ruby <3.2 to
+      # transpile patterns with variable (instance, class, global) binding
+      class BindVarsPattern < PatternMatching
+        NAME = "pattern-matching-find-pattern"
+        SYNTAX_PROBE = "case 0; in @a; true; else; 1; end"
+        MIN_SUPPORTED_VERSION = Gem::Version.new(RubyNext::NEXT_VERSION)
+
+        def on_case_match(node)
+          @has_vars_pattern = false
+          process_regular_node(node).then do |new_node|
+            return new_node unless has_vars_pattern
+            super(node)
+          end
+        end
+
+        def on_match_pattern(node)
+          @has_vars_pattern = false
+          process_regular_node(node).then do |new_node|
+            return new_node unless has_vars_pattern
+            super(node)
+          end
+        end
+
+        def on_match_pattern_p(node)
+          @has_vars_pattern = false
+          process_regular_node(node).then do |new_node|
+            return new_node unless has_vars_pattern
+            super(node)
+          end
+        end
+
+        def on_match_var(node)
+          @has_vars_pattern = true if node.children[0].is_a?(::Parser::AST::Node)
+          super(node)
+        end
+
+        private
+
+        attr_reader :has_vars_pattern
+      end
+    end
+  end
+end

--- a/lib/ruby-next/language/rewriters/find_pattern.rb
+++ b/lib/ruby-next/language/rewriters/find_pattern.rb
@@ -22,7 +22,7 @@ module RubyNext
           end
         end
 
-        def on_in_match(node)
+        def on_match_pattern(node)
           @has_find_pattern = false
           process_regular_node(node).then do |new_node|
             return new_node unless has_find_pattern

--- a/lib/ruby-next/language/rewriters/in_pattern.rb
+++ b/lib/ruby-next/language/rewriters/in_pattern.rb
@@ -16,39 +16,7 @@ module RubyNext
 
         # Make case-match no-op
         def on_case_match(node)
-          node
-        end
-
-        def on_match_pattern_p(node)
-          context.track! self
-
-          @deconstructed_keys = {}
-          @predicates = Predicates::Noop.new
-
-          matchee =
-            s(:begin, s(:lvasgn, MATCHEE, node.children[0]))
-
-          pattern =
-            locals.with(
-              matchee: MATCHEE,
-              arr: MATCHEE_ARR,
-              hash: MATCHEE_HASH
-            ) do
-              send(
-                :"#{node.children[1].type}_clause",
-                node.children[1]
-              )
-            end
-
-          node.updated(
-            :and,
-            [
-              matchee,
-              pattern
-            ]
-          ).tap do |new_node|
-            replace(node.loc.expression, inline_blocks(unparse(new_node)))
-          end
+          process_regular_node(node)
         end
       end
     end

--- a/lib/ruby-next/language/rewriters/pin_vars_pattern.rb
+++ b/lib/ruby-next/language/rewriters/pin_vars_pattern.rb
@@ -22,7 +22,15 @@ module RubyNext
           end
         end
 
-        def on_in_match(node)
+        def on_match_pattern(node)
+          @has_pin_vars = false
+          process_regular_node(node).then do |new_node|
+            return new_node unless has_pin_vars
+            super(node)
+          end
+        end
+
+        def on_match_pattern_p(node)
           @has_pin_vars = false
           process_regular_node(node).then do |new_node|
             return new_node unless has_pin_vars

--- a/ruby-next-core.gemspec
+++ b/ruby-next-core.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.executables = ["ruby-next"]
 
-  s.add_development_dependency "ruby-next-parser", ">= 3.1.0.1"
+  s.add_development_dependency "ruby-next-parser", ">= 3.1.1.0"
   s.add_development_dependency "unparser", "~> 0.6.0"
 end

--- a/ruby-next.gemspec
+++ b/ruby-next.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "ruby-next-core", RubyNext::VERSION
-  s.add_dependency "ruby-next-parser", ">= 3.1.0.1"
+  s.add_dependency "ruby-next-parser", ">= 3.1.1.0"
   s.add_dependency "unparser", "~> 0.6.0"
 end


### PR DESCRIPTION
### What is the purpose of this pull request?

See https://bugs.ruby-lang.org/issues/18408

### What changes did you make? (overview)

Added new rewriter, which transpiles pattern matching code in case it uses binding to ivar, cvar or gvar.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md
