### PR TITLE
Text rewriters

### DIFF
--- a/.github/workflows/truffle-test.yml
+++ b/.github/workflows/truffle-test.yml
@@ -38,18 +38,15 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      CORE_EXT: gem
-      RUBY_NEXT_CORE_STRATEGY: core_ext
       BUNDLE_JOBS: 4
       BUNDLE_RETRY: 3
       BUNDLE_PATH: /home/runner/bundle
-      TRUFFLERUBYOPT: "--engine.Mode=latency"
       CI: true
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: truffleruby-head
+        ruby-version: truffleruby
         bundler-cache: true
     - name: Restore transpiled files
       uses: actions/download-artifact@v1
@@ -62,23 +59,20 @@ jobs:
 
   truffle-test-language:
     needs: transpile
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     env:
-      CORE_EXT: gem
-      RUBY_NEXT_CORE_STRATEGY: core_ext
       BUNDLE_JOBS: 4
       BUNDLE_RETRY: 3
       BUNDLE_PATH: /home/runner/bundle
-      TRUFFLERUBYOPT: "--engine.Mode=latency"
       CI: true
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: truffleruby-head
+        ruby-version: truffleruby
         bundler-cache: true
     - name: Restore transpiled files
       uses: actions/download-artifact@v1
@@ -87,11 +81,7 @@ jobs:
         path: lib/.rbnext
     - name: Run MSpec Language
       run: |
-        ruby -e '
-          Dir.glob("spec/language/**/*_spec.rb").all? do |file|
-            system("bundle", "exec", "bin/mspec", file)
-          end || raise("Failures")
-        '
+        bundle exec bin/mspec :language
 
   truffle-test-integration:
     needs: transpile
@@ -100,18 +90,15 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      CORE_EXT: gem
-      RUBY_NEXT_CORE_STRATEGY: core_ext
       BUNDLE_JOBS: 4
       BUNDLE_RETRY: 3
       BUNDLE_PATH: /home/runner/bundle
-      TRUFFLERUBYOPT: "--engine.Mode=latency"
       CI: true
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: truffleruby-head
+        ruby-version: truffleruby
         bundler-cache: true
     - name: Restore transpiled files
       uses: actions/download-artifact@v1
@@ -120,8 +107,4 @@ jobs:
         path: lib/.rbnext
     - name: Run MSpec integration
       run: |
-        ruby -e '
-          Dir.glob("spec/integration/**/*_spec.rb").all? do |file|
-            system("bundle", "exec", "bin/mspec", file)
-          end || raise("Failures")
-        '
+        bundle exec bin/mspec :integration

--- a/.github/workflows/truffle-test.yml
+++ b/.github/workflows/truffle-test.yml
@@ -56,12 +56,35 @@ jobs:
       with:
         name: ruby-next-transpiled
         path: lib/.rbnext
-    - name: Download MSpec
-      run: |
-        git clone https://github.com/ruby/mspec.git mspec
     - name: Run MSpec Core
       run: |
         bundle exec bin/mspec :core
+
+  truffle-test-language:
+    needs: transpile
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    env:
+      CORE_EXT: gem
+      RUBY_NEXT_CORE_STRATEGY: core_ext
+      BUNDLE_JOBS: 4
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: /home/runner/bundle
+      TRUFFLERUBYOPT: "--engine.Mode=latency"
+      CI: true
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: truffleruby-head
+        bundler-cache: true
+    - name: Restore transpiled files
+      uses: actions/download-artifact@v1
+      with:
+        name: ruby-next-transpiled
+        path: lib/.rbnext
     - name: Run MSpec Language
       run: |
         ruby -e '

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ AllCops:
     - 'mspec/**/*'
     - 'benchmarks/**/*'
     - '**/*/syntax_error.rb'
+    - 'spec/cli/fixtures/custom/a.rb'
   DisplayCopNames: true
   TargetRubyVersion: next
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-- Add text rewriters. ([@palkan][])
+- Add text rewriters and `--import-rewriter` option to `nextify`. ([@palkan][])
 
 - Use `.rbnextrc` arguments for runtime transpiling and auto-transpiling gems. ([@palkan][])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add text rewriters. ([@palkan][])
+
 - Use `.rbnextrc` arguments for runtime transpiling and auto-transpiling gems. ([@palkan][])
 
 - Stop testing Ruby <2.3. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Usage: ruby-next nextify DIRECTORY_OR_FILE [options]
         --[no-]refine                Do not inject `using RubyNext`
         --list-rewriters             List available rewriters
         --rewrite=REWRITERS...       Specify particular Ruby features to rewrite
+        --import-rewriter=PATHS...   Specify the paths to custom rewriters to load
     -h, --help                       Print help
     -V                               Turn on verbose mode
         --dry-run                    Print verbose output without generating files
@@ -561,7 +562,7 @@ It's too early, Ruby 3.1 has just been released. See its features in the [suppor
 
 ## Custom syntax rewriters
 
-Wonder what would happen if Ruby get a null coallescing operator (`??=`) or some other syntactic feature you want to try out? Ruby Next is here to help you!
+Wonder what would happen if Ruby get a null coalescing operator (`??=`) or some other syntactic feature you want to try out? Ruby Next is here to help you!
 
 Ruby Next allows you to write your own syntax rewriters. Full-featured rewriters (used by Ruby Next itself) operate on AST and usually require parser modifications. However, we also support text-based rewriters which can be used to experiment with new syntax much quicker without dealing with grammars, parsers and syntax trees.
 
@@ -569,6 +570,12 @@ To implement a text-based rewriter, you need to create a new class inherited fro
 
 ```ruby
 class MethodReferenceRewriter < RubyNext::Language::Rewriters::Text
+  # Rewriter configuration includes its name, a syntax probe and a minimum supported Ruby version.
+  # The latter two are used to determine whether the rewriter should be activated for the current file in runtime or when running `ruby-next nextify`.
+  NAME = "method-reference"
+  SYNTAX_PROBE = "Language.:transform"
+  MIN_SUPPORTED_VERSION = Gem::Version.new(RubyNext::NEXT_VERSION)
+
   def safe_rewrite(source)
     source.gsub(/\.:([\w_]+)/) do |match|
       context.track! self
@@ -587,6 +594,8 @@ The `context` object is responsible for tracking if the rewriter was used for th
 The `#safe_rewrite` method operates on the normalized source code (i.e., without comments and string literals). It's useful when you want to avoid transpiling inside strings or comments. If you want to transpile the original contents, you can use the `#rewrite` method instead.
 
 Under the hood, `#safe_rewrite` uses [Paco][] to parse the source and separate string literals from the rest of the code. You can also leverage [Paco][] in your text rewriters, if you want more control on the parsing process.
+
+When using the `ruby-next nextify` command, you can load custom rewriters via the `--import-rewriter` option.
 
 ## Known limitations
 

--- a/forspell.dict
+++ b/forspell.dict
@@ -28,3 +28,4 @@ unparser
 realpath
 assignees
 palkan
+Paco

--- a/lib/ruby-next/commands/nextify.rb
+++ b/lib/ruby-next/commands/nextify.rb
@@ -33,6 +33,7 @@ module RubyNext
         print_help = false
         print_rewriters = false
         rewriter_names = []
+        custom_rewriters = []
         @single_version = false
         @overwrite = false
 
@@ -84,6 +85,10 @@ module RubyNext
             rewriter_names << val
           end
 
+          opts.on("--import-rewriter=REWRITERS...", "Specify paths to load custom rewritiers") do |val|
+            custom_rewriters << val
+          end
+
           opts.on("-h", "--help", "Print help") do
             print_help = true
           end
@@ -96,6 +101,11 @@ module RubyNext
         if print_help
           $stdout.puts optparser.help
           exit 0
+        end
+
+        # Load custom rewriters
+        custom_rewriters.each do |path|
+          Kernel.load path
         end
 
         if print_rewriters

--- a/lib/ruby-next/irb.rb
+++ b/lib/ruby-next/irb.rb
@@ -9,14 +9,14 @@ require "ruby-next/language"
 # IRB extension to transpile code before evaluating
 module RubyNext
   module IRBExt
-    def evaluate(context, statements, *args)
+    def eval(statements, *args)
       new_statements = ::RubyNext::Language.transform(
         statements,
         rewriters: ::RubyNext::Language.current_rewriters,
         using: false
       )
 
-      super(context, new_statements, *args)
+      super(new_statements, *args)
     end
   end
 end

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -62,7 +62,6 @@ module RubyNext
     end
 
     class << self
-      attr_accessor :rewriters
       attr_reader :include_patterns
       attr_reader :exclude_patterns
 
@@ -187,7 +186,7 @@ module RubyNext
 
       def text_rewrite(source, rewriters:, using:, context:)
         rewriters.inject(source) do |src, rewriter|
-          rewriter.new(context).rewrite(src)
+          rewriter.new(context).safe_rewrite(src)
         end.then do |new_source|
           next source unless context.dirty?
 
@@ -255,7 +254,7 @@ module RubyNext
     rewriters << Rewriters::InPattern
 
     require "ruby-next/language/rewriters/3.0/endless_method"
-    RubyNext::Language.rewriters << RubyNext::Language::Rewriters::EndlessMethod
+    rewriters << RubyNext::Language::Rewriters::EndlessMethod
 
     require "ruby-next/language/rewriters/3.1/oneline_pattern_parensless"
     rewriters << Rewriters::OnelinePatternParensless

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -199,7 +199,6 @@ module RubyNext
     end
 
     self.rewriters = []
-    self.text_rewriters = []
     self.watch_dirs = [].tap do |dirs|
       # For backward compatibility
       dirs.define_singleton_method(:<<) do |dir|

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -70,7 +70,7 @@ module RubyNext
         @watch_dirs
       end
 
-      attr_accessor :rewriters, :text_rewriters
+      attr_accessor :rewriters
 
       attr_accessor :strategy
 
@@ -186,7 +186,7 @@ module RubyNext
 
       def text_rewrite(source, rewriters:, using:, context:)
         rewriters.inject(source) do |src, rewriter|
-          rewriter.new(context).safe_rewrite(src)
+          rewriter.new(context).rewrite(src)
         end.then do |new_source|
           next source unless context.dirty?
 

--- a/lib/ruby-next/language/paco_parser.rb
+++ b/lib/ruby-next/language/paco_parser.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "paco"
+
+require "ruby-next/language/paco_parsers/base"
+require "ruby-next/language/paco_parsers/comments"
+require "ruby-next/language/paco_parsers/string_literals"

--- a/lib/ruby-next/language/paco_parsers/base.rb
+++ b/lib/ruby-next/language/paco_parsers/base.rb
@@ -25,6 +25,22 @@ module RubyNext
             (index.column > 1) ? failed("1 column") : string(str)
           end
         end
+
+        def balanced(l, r, inner)
+          left = string(l)
+          right = string(r)
+
+          many(
+            alt(
+              seq(
+                left,
+                lazy { balanced(l, r, inner) },
+                right
+              ),
+              not_followed_by(right).bind { inner }
+            )
+          )
+        end
       end
     end
   end

--- a/lib/ruby-next/language/paco_parsers/base.rb
+++ b/lib/ruby-next/language/paco_parsers/base.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module RubyNext
+  module Language
+    module PacoParsers
+      class Base
+        include Paco
+
+        def parse(io)
+          default.parse(io)
+        end
+
+        private
+
+        def anything_between(left, right)
+          seq(
+            left,
+            many(not_followed_by(right).bind { any_char }).join,
+            right
+          ).join
+        end
+
+        def starting_string(str)
+          index.bind do |index|
+            (index.column > 1) ? failed("1 column") : string(str)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-next/language/paco_parsers/comments.rb
+++ b/lib/ruby-next/language/paco_parsers/comments.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module RubyNext
+  module Language
+    module PacoParsers
+      class Comments < Base
+        def default
+          alt(
+            line_comment,
+            block_comment
+          )
+        end
+
+        # Matches a Ruby line comment (from `#` till the end of the line)
+        def line_comment
+          anything_between(string("#"), end_of_line)
+        end
+
+        # Matches a Ruby block comment (from `=begin` till `=end`)
+        def block_comment
+          anything_between(starting_string("=begin"), starting_string("=end"))
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-next/language/paco_parsers/string_literals.rb
+++ b/lib/ruby-next/language/paco_parsers/string_literals.rb
@@ -66,7 +66,7 @@ module RubyNext
                   seq(string("\\"), right).fmap { [:literal, _1] },
                   interpolate ? seq(
                     string('#{'),
-                    lazy { alt(balanced("{", "}"), many(none_of("}"))) },
+                    lazy { alt(balanced("{", "}", alt(all_strings, any_char)), many(none_of("}"))) },
                     string("}")
                   ) : nil,
                   not_followed_by(right).bind { any_char }.fmap { [:literal, _1] }
@@ -78,22 +78,6 @@ module RubyNext
         end
 
         private
-
-        def balanced(l, r)
-          left = string(l)
-          right = string(r)
-
-          many(
-            alt(
-              seq(
-                left,
-                lazy { balanced(l, r) },
-                right
-              ),
-              not_followed_by(right).bind { alt(all_strings, any_char) }
-            )
-          )
-        end
 
         def reduce_tokens(tokens)
           state = :literal

--- a/lib/ruby-next/language/paco_parsers/string_literals.rb
+++ b/lib/ruby-next/language/paco_parsers/string_literals.rb
@@ -7,6 +7,12 @@ module RubyNext
         PAIRS = {"[" => "]", "{" => "}", "<" => ">"}.freeze
 
         def default
+          all_strings.fmap do |result|
+            reduce_tokens(result.flatten)
+          end
+        end
+
+        def all_strings
           alt(
             single_quoted,
             double_quoted,
@@ -25,46 +31,93 @@ module RubyNext
               end_symbol = string(PAIRS[char] || char)
               escapable_string(succeed(char), end_symbol)
             end
-          ).join
+          )
         end
 
         def single_quoted
           escapable_string(string("'"))
         end
 
-        # TODO: add interpolation
         def quoted_expanded
           seq(
             alt(string("%Q"), string("%")),
             any_char.bind do |char|
               end_symbol = string(PAIRS[char] || char)
-              escapable_string(succeed(char), end_symbol)
+              escapable_string(succeed(char), end_symbol, interpolate: true)
             end
-          ).join
+          )
         end
 
-        # TODO: add interpolation
         def external_cmd_exec
-          escapable_string(string("`"))
+          escapable_string(string("`"), interpolate: true)
         end
 
-        # TODO: add interpolation
         def double_quoted
-          escapable_string(string('"'))
+          escapable_string(string('"'), interpolate: true)
         end
 
-        def escapable_string(left, right = nil)
+        def escapable_string(left, right = nil, interpolate: false)
           right ||= left
           seq(
             left,
             many(
               alt(
-                seq(string("\\"), right),
-                not_followed_by(right).bind { any_char }
+                *[
+                  seq(string("\\"), right).fmap { [:literal, _1] },
+                  interpolate ? seq(
+                    string('#{'),
+                    lazy { alt(balanced("{", "}"), many(none_of("}"))) },
+                    string("}")
+                  ) : nil,
+                  not_followed_by(right).bind { any_char }.fmap { [:literal, _1] }
+                ].compact
               )
-            ).join,
+            ),
             right
-          ).join
+          )
+        end
+
+        private
+
+        def balanced(l, r)
+          left = string(l)
+          right = string(r)
+
+          many(
+            alt(
+              seq(
+                left,
+                lazy { balanced(l, r) },
+                right
+              ),
+              not_followed_by(right).bind { alt(all_strings, any_char) }
+            )
+          )
+        end
+
+        def reduce_tokens(tokens)
+          state = :literal
+
+          tokens.each_with_object([]) do |v, acc|
+            if v == :literal
+              acc << [:literal, +""] unless state == :literal
+              state = :next_literal
+              next acc
+            end
+
+            if state == :next_literal
+              state = :literal
+              acc.last[1] << v
+              next acc
+            end
+
+            if state == :literal
+              acc << [:code, +""]
+            end
+
+            state = :code
+            acc.last[1] << v
+          end
         end
       end
     end

--- a/lib/ruby-next/language/paco_parsers/string_literals.rb
+++ b/lib/ruby-next/language/paco_parsers/string_literals.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module RubyNext
+  module Language
+    module PacoParsers
+      class StringLiterals < Base
+        PAIRS = {"[" => "]", "{" => "}", "<" => ">"}.freeze
+
+        def default
+          alt(
+            single_quoted,
+            double_quoted,
+            external_cmd_exec,
+            quoted,
+            quoted_expanded
+          )
+          # heredoc,
+          # heredoc_expanded
+        end
+
+        def quoted
+          seq(
+            string("%q"),
+            any_char.bind do |char|
+              end_symbol = string(PAIRS[char] || char)
+              escapable_string(succeed(char), end_symbol)
+            end
+          ).join
+        end
+
+        def single_quoted
+          escapable_string(string("'"))
+        end
+
+        # TODO: add interpolation
+        def quoted_expanded
+          seq(
+            alt(string("%Q"), string("%")),
+            any_char.bind do |char|
+              end_symbol = string(PAIRS[char] || char)
+              escapable_string(succeed(char), end_symbol)
+            end
+          ).join
+        end
+
+        # TODO: add interpolation
+        def external_cmd_exec
+          escapable_string(string("`"))
+        end
+
+        # TODO: add interpolation
+        def double_quoted
+          escapable_string(string('"'))
+        end
+
+        def escapable_string(left, right = nil)
+          right ||= left
+          seq(
+            left,
+            many(
+              alt(
+                seq(string("\\"), right),
+                not_followed_by(right).bind { any_char }
+              )
+            ).join,
+            right
+          ).join
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-next/language/rewriters/abstract.rb
+++ b/lib/ruby-next/language/rewriters/abstract.rb
@@ -5,8 +5,8 @@ module RubyNext
     module Rewriters
       class Abstract < ::Parser::TreeRewriter
         NAME = "custom-rewriter"
-        SYNTAX_PROBE = "1"
-        MIN_SUPPORTED_VERSION = Gem::Version.new("2.2.0")
+        SYNTAX_PROBE = "1 = [}"
+        MIN_SUPPORTED_VERSION = Gem::Version.new(RubyNext::NEXT_VERSION)
 
         class << self
           # Returns true if the syntax is not supported

--- a/lib/ruby-next/language/rewriters/abstract.rb
+++ b/lib/ruby-next/language/rewriters/abstract.rb
@@ -4,6 +4,10 @@ module RubyNext
   module Language
     module Rewriters
       class Abstract < ::Parser::TreeRewriter
+        NAME = "custom-rewriter"
+        SYNTAX_PROBE = "1"
+        MIN_SUPPORTED_VERSION = Gem::Version.new("2.2.0")
+
         class << self
           # Returns true if the syntax is not supported
           # by the current Ruby (performs syntax check, not version check)

--- a/lib/ruby-next/language/rewriters/abstract.rb
+++ b/lib/ruby-next/language/rewriters/abstract.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module RubyNext
+  module Language
+    module Rewriters
+      class Abstract < ::Parser::TreeRewriter
+        class << self
+          # Returns true if the syntax is not supported
+          # by the current Ruby (performs syntax check, not version check)
+          def unsupported_syntax?
+            save_verbose, $VERBOSE = $VERBOSE, nil
+            eval_mid = Kernel.respond_to?(:eval_without_ruby_next) ? :eval_without_ruby_next : :eval
+            Kernel.send eval_mid, self::SYNTAX_PROBE, nil, __FILE__, __LINE__
+            false
+          rescue SyntaxError, StandardError
+            true
+          ensure
+            $VERBOSE = save_verbose
+          end
+
+          # Returns true if the syntax is supported
+          # by the specified version
+          def unsupported_version?(version)
+            version < self::MIN_SUPPORTED_VERSION
+          end
+
+          def text?
+            false
+          end
+
+          def ast?
+            false
+          end
+
+          private
+
+          def transform(source)
+            Language.transform(source, rewriters: [self], using: false)
+          end
+        end
+
+        def initialize(context)
+          @context = context
+          super()
+        end
+
+        private
+
+        attr_reader :context
+      end
+    end
+  end
+end

--- a/lib/ruby-next/language/rewriters/proposed.rb
+++ b/lib/ruby-next/language/rewriters/proposed.rb
@@ -3,7 +3,7 @@
 # Load experimental, proposed etc. Ruby features
 
 require "ruby-next/language/rewriters/proposed/method_reference"
-RubyNext::Language.rewriters << RubyNext::Language::Rewriters::MethodReference
+RubyNext::Language.text_rewriters << RubyNext::Language::Rewriters::MethodReference
 
 require "ruby-next/language/rewriters/proposed/bind_vars_pattern"
 RubyNext::Language.rewriters << RubyNext::Language::Rewriters::BindVarsPattern

--- a/lib/ruby-next/language/rewriters/proposed.rb
+++ b/lib/ruby-next/language/rewriters/proposed.rb
@@ -3,7 +3,7 @@
 # Load experimental, proposed etc. Ruby features
 
 require "ruby-next/language/rewriters/proposed/method_reference"
-RubyNext::Language.text_rewriters << RubyNext::Language::Rewriters::MethodReference
+RubyNext::Language.rewriters << RubyNext::Language::Rewriters::MethodReference
 
 require "ruby-next/language/rewriters/proposed/bind_vars_pattern"
 RubyNext::Language.rewriters << RubyNext::Language::Rewriters::BindVarsPattern

--- a/lib/ruby-next/language/rewriters/proposed/method_reference.rb
+++ b/lib/ruby-next/language/rewriters/proposed/method_reference.rb
@@ -11,26 +11,12 @@ module RubyNext
         SYNTAX_PROBE = "Language.:transform"
         MIN_SUPPORTED_VERSION = Gem::Version.new(RubyNext::NEXT_VERSION)
 
-        def on_meth_ref(node)
-          context.track! self
+        def rewrite(source)
+          source.gsub(/\.:([\w_]+)/) do |match|
+            context.track! self
 
-          receiver, mid = *node.children
-
-          replace(
-            node.children.first.loc.expression.end.join(
-              node.loc.expression.end
-            ),
-            ".method(:#{mid})"
-          )
-
-          node.updated(
-            :send,
-            [
-              receiver,
-              :method,
-              s(:sym, mid)
-            ]
-          )
+            ".method(:#{$1})"
+          end
         end
       end
     end

--- a/lib/ruby-next/language/rewriters/proposed/method_reference.rb
+++ b/lib/ruby-next/language/rewriters/proposed/method_reference.rb
@@ -6,7 +6,7 @@ RubyNext::Language.parser_class = ::Parser::RubyNext
 module RubyNext
   module Language
     module Rewriters
-      class MethodReference < Base
+      class MethodReference < Text
         NAME = "method-reference"
         SYNTAX_PROBE = "Language.:transform"
         MIN_SUPPORTED_VERSION = Gem::Version.new(RubyNext::NEXT_VERSION)

--- a/lib/ruby-next/language/rewriters/proposed/method_reference.rb
+++ b/lib/ruby-next/language/rewriters/proposed/method_reference.rb
@@ -11,7 +11,7 @@ module RubyNext
         SYNTAX_PROBE = "Language.:transform"
         MIN_SUPPORTED_VERSION = Gem::Version.new(RubyNext::NEXT_VERSION)
 
-        def rewrite(source)
+        def safe_rewrite(source)
           source.gsub(/\.:([\w_]+)/) do |match|
             context.track! self
 

--- a/lib/ruby-next/language/rewriters/text.rb
+++ b/lib/ruby-next/language/rewriters/text.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RubyNext
+  module Language
+    module Rewriters
+      class Text < Abstract
+        def self.text?
+          true
+        end
+
+        def rewrite(source)
+          source
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-next/language/rewriters/text.rb
+++ b/lib/ruby-next/language/rewriters/text.rb
@@ -1,15 +1,79 @@
 # frozen_string_literal: true
 
+require "ruby-next/language/paco_parser"
+
 module RubyNext
   module Language
     module Rewriters
       class Text < Abstract
+        class Parser
+          include Paco
+
+          attr_reader :store
+
+          def initialize
+            @store = []
+          end
+
+          def normalizing(source)
+            many(
+              alt(
+                ruby_comment,
+                ruby_string,
+                ruby_code
+              )
+            ).parse(source, with_callstack: true)
+              .then(&:join)
+              .then do
+                if block_given?
+                  yield _1
+                else
+                  _1
+                end
+              end
+              .then do |new_source|
+              restore(new_source)
+            end
+          end
+
+          def ruby_comment
+            PacoParsers::Comments.new.default.fmap do |result|
+              store << result
+              "# A#{store.size}Я\n"
+            end
+          end
+
+          def ruby_string
+            PacoParsers::StringLiterals.new.default.fmap do |result|
+              store << result
+              "%|A#{store.size}Я|"
+            end
+          end
+
+          def ruby_code
+            any_char
+          end
+
+          def restore(source)
+            source.gsub(/(?:\# |%\|)A(\d+)Я(?:\||\n)/m) do |*args|
+              store[$1.to_i - 1]
+            end
+          end
+        end
+
         def self.text?
           true
         end
 
         def rewrite(source)
           source
+        end
+
+        # Rewrite source code by ignoring string literals and comments
+        def safe_rewrite(source)
+          Parser.new.normalizing(source) do |normalized|
+            rewrite(normalized)
+          end
         end
       end
     end

--- a/lib/ruby-next/language/rewriters/text.rb
+++ b/lib/ruby-next/language/rewriters/text.rb
@@ -65,15 +65,15 @@ module RubyNext
           true
         end
 
+        # Rewrite source code by ignoring string literals and comments
         def rewrite(source)
-          source
+          Parser.new.normalizing(source) do |normalized|
+            safe_rewrite(normalized)
+          end
         end
 
-        # Rewrite source code by ignoring string literals and comments
         def safe_rewrite(source)
-          Parser.new.normalizing(source) do |normalized|
-            rewrite(normalized)
-          end
+          source
         end
       end
     end

--- a/ruby-next-core.gemspec
+++ b/ruby-next-core.gemspec
@@ -44,4 +44,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "require-hooks", "~> 0.2"
   s.add_development_dependency "ruby-next-parser", ">= 3.2.2.0"
   s.add_development_dependency "unparser", "~> 0.6.0"
+  s.add_development_dependency "paco", "~> 0.2"
 end

--- a/ruby-next.gemspec
+++ b/ruby-next.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.add_dependency "ruby-next-parser", ">= 3.1.1.0"
   s.add_dependency "require-hooks", "~> 0.2"
   s.add_dependency "unparser", "~> 0.6.0"
+  s.add_dependency "paco", "~> 0.2"
 end

--- a/spec/cli/fixtures/custom/a.rb
+++ b/spec/cli/fixtures/custom/a.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# NOTE: A comment
+2 => a
+
+b := 1
+
+puts "Sum: #{a + b}"

--- a/spec/cli/fixtures/custom/assignment_rewriter.rb
+++ b/spec/cli/fixtures/custom/assignment_rewriter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AssignmentRewriter < RubyNext::Language::Rewriters::Text
+  NAME = "assignment-operator"
+  MIN_SUPPORTED_VERSION = Gem::Version.new(RubyNext::NEXT_VERSION)
+
+  def safe_rewrite(source)
+    source.gsub(":=") do |match|
+      context.track! self
+
+      "="
+    end
+  end
+end
+
+RubyNext::Language.rewriters << AssignmentRewriter

--- a/spec/cli/fixtures/custom/assignment_rewriter.rb
+++ b/spec/cli/fixtures/custom/assignment_rewriter.rb
@@ -1,15 +1,23 @@
 # frozen_string_literal: true
 
 class AssignmentRewriter < RubyNext::Language::Rewriters::Text
-  NAME = "assignment-operator"
-  MIN_SUPPORTED_VERSION = Gem::Version.new(RubyNext::NEXT_VERSION)
+  parser do
+    def default
+      many(
+        alt(
+          c_assignment,
+          any_char
+        )
+      )
+    end
+
+    def c_assignment
+      string(":=").fmap { track! }.fmap { "=" }
+    end
+  end
 
   def safe_rewrite(source)
-    source.gsub(":=") do |match|
-      context.track! self
-
-      "="
-    end
+    parse(source).join
   end
 end
 

--- a/spec/cli/fixtures/custom/comment_rewriter.rb
+++ b/spec/cli/fixtures/custom/comment_rewriter.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "date"
+
+class NoteDateRewriter < RubyNext::Language::Rewriters::Text
+  NAME = "note-comment-date"
+  MIN_SUPPORTED_VERSION = Gem::Version.new(RubyNext::NEXT_VERSION)
+
+  def rewrite(source)
+    source.gsub("# NOTE:") do |match|
+      context.track! self
+
+      "# NOTE (#{Date.today}):"
+    end
+  end
+end
+
+RubyNext::Language.rewriters << NoteDateRewriter

--- a/spec/cli/nextify_spec.rb
+++ b/spec/cli/nextify_spec.rb
@@ -384,4 +384,34 @@ describe "ruby-next nextify" do
       end
     end
   end
+
+  context "with --import-rewriter" do
+    after do
+      FileUtils.rm_rf(File.join(__dir__, "fixtures", ".rbnext"))
+    end
+
+    it "imports custom rewriters" do
+      run_ruby_next(
+        "nextify #{File.join(__dir__, "fixtures", "custom", "a.rb")} " \
+        "--import-rewriter=#{File.join(__dir__, "fixtures", "custom", "assignment_rewriter.rb")} " \
+        "--import-rewriter=#{File.join(__dir__, "fixtures", "custom", "comment_rewriter.rb")} " \
+        "--output=#{File.join(__dir__, "fixtures", ".rbnext", "a.rb")} " \
+        "--min-version=2.6 --single-version"
+      ) do |_status, _output, err|
+        File.exist?(File.join(__dir__, "fixtures", ".rbnext", "a.rb")).should equal true
+
+        require "date"
+        today = Date.today
+
+        contents = File.read(File.join(__dir__, "fixtures", ".rbnext", "a.rb"))
+        contents.should include("# NOTE (#{today}):")
+
+        run_ruby(
+          File.join(__dir__, "fixtures", ".rbnext", "a.rb")
+        ) do |_status, output, _err|
+          output.should include("Sum: 3")
+        end
+      end
+    end
+  end
 end

--- a/spec/integration/fixtures/method_reference.rb
+++ b/spec/integration/fixtures/method_reference.rb
@@ -3,7 +3,7 @@
 require "json"
 
 def main(val)
-  "status: #{JSON.:parse.call(val)["status"]}"
+  "status: " + JSON.:parse.call(val)["status"].to_s
 end
 
 # p main('{}') #=> "status: nil"

--- a/spec/integration/fixtures/method_reference.rb
+++ b/spec/integration/fixtures/method_reference.rb
@@ -3,7 +3,7 @@
 require "json"
 
 def main(val)
-  "status: " + JSON.:parse.call(val)["status"].to_s
+  "status: #{JSON.:parse.call(val)["status"]}"
 end
 
 # p main('{}') #=> "status: nil"

--- a/spec/lib/language/rewriters/text_spec.rb
+++ b/spec/lib/language/rewriters/text_spec.rb
@@ -50,4 +50,24 @@ describe "Text rewriters" do
       a = "Hello, LANG := RUBY"
     RUBY
   end
+
+  it "supports interpolation" do
+    new_source = @rewriter.rewrite(<<~'RUBY')
+      a := "Hello, LANG := #{ x := %Q{RUBY := #{ a := 2 }} }"
+    RUBY
+
+    new_source.should == <<~'RUBY'
+      a = "Hello, LANG := #{ x = %Q{RUBY := #{ a = 2 }} }"
+    RUBY
+  end
+
+  it "does not interpolate non-interpolatable strings" do
+    new_source = @rewriter.rewrite(<<~'RUBY')
+      a := 'Hello, LANG := #{ x := "RUBY" }'
+    RUBY
+
+    new_source.should == <<~'RUBY'
+      a = 'Hello, LANG := #{ x := "RUBY" }'
+    RUBY
+  end
 end

--- a/spec/lib/language/rewriters/text_spec.rb
+++ b/spec/lib/language/rewriters/text_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "../../../spec_helper"
+
+module RewritersSpecs
+  class TextRewriter < RubyNext::Language::Rewriters::Text
+    def rewrite(source)
+      source.gsub(":=", "=")
+    end
+  end
+end
+
+describe "Text rewriters" do
+  before(:each) do
+    @rewriter = RewritersSpecs::TextRewriter.new(RubyNext::Language::TransformContext.new)
+  end
+
+  it "rewrites code" do
+    new_source = @rewriter.safe_rewrite(<<~RUBY)
+      a := "Hello, 世界"
+      
+      b:=42
+    RUBY
+
+    new_source.should == <<~RUBY
+      a = "Hello, 世界"
+      
+      b=42
+    RUBY
+  end
+
+  it "doesn't rewrite comments" do
+    new_source = @rewriter.safe_rewrite(<<~RUBY)
+      # This is a comment := about assignment
+      a := "Hello, 世界"
+    RUBY
+
+    new_source.should == <<~RUBY
+      # This is a comment := about assignment
+      a = "Hello, 世界"
+    RUBY
+  end
+
+  it "doesn't rewrite string literals" do
+    new_source = @rewriter.safe_rewrite(<<~RUBY)
+      a := "Hello, LANG := RUBY"
+    RUBY
+
+    new_source.should == <<~RUBY
+      a = "Hello, LANG := RUBY"
+    RUBY
+  end
+end

--- a/spec/lib/language/rewriters/text_spec.rb
+++ b/spec/lib/language/rewriters/text_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../../spec_helper"
 
 module RewritersSpecs
   class TextRewriter < RubyNext::Language::Rewriters::Text
-    def rewrite(source)
+    def safe_rewrite(source)
       source.gsub(":=", "=")
     end
   end
@@ -16,7 +16,7 @@ describe "Text rewriters" do
   end
 
   it "rewrites code" do
-    new_source = @rewriter.safe_rewrite(<<~RUBY)
+    new_source = @rewriter.rewrite(<<~RUBY)
       a := "Hello, 世界"
       
       b:=42
@@ -30,7 +30,7 @@ describe "Text rewriters" do
   end
 
   it "doesn't rewrite comments" do
-    new_source = @rewriter.safe_rewrite(<<~RUBY)
+    new_source = @rewriter.rewrite(<<~RUBY)
       # This is a comment := about assignment
       a := "Hello, 世界"
     RUBY
@@ -42,7 +42,7 @@ describe "Text rewriters" do
   end
 
   it "doesn't rewrite string literals" do
-    new_source = @rewriter.safe_rewrite(<<~RUBY)
+    new_source = @rewriter.rewrite(<<~RUBY)
       a := "Hello, LANG := RUBY"
     RUBY
 

--- a/spec/support/command_testing.rb
+++ b/spec/support/command_testing.rb
@@ -36,8 +36,10 @@ module Kernel
     run_command("#{RUBY_RUNNER} #{File.join(__dir__, "../../bin/ruby-next")} #{command}", **options, &block)
   end
 
-  def run_irb(flags = nil, input: [], **options, &block)
+  def run_irb(flags = nil, input: [], env: {}, **options, &block)
     input << "exit"
-    run_command("bundle exec irb --noecho -rbundler/setup -I#{File.expand_path(File.join(__dir__, "../../lib"))} #{flags}", input: input, **options, &block)
+    # Override HOME to make sure we're not loading default ~/.irbrc
+    env["HOME"] = File.join(__dir__)
+    run_command("bundle exec irb --noecho -rbundler/setup -I#{File.expand_path(File.join(__dir__, "../../lib"))} #{flags}", input: input, env: env, **options, &block)
   end
 end


### PR DESCRIPTION
### What is the purpose of this pull request?

Provide a simple rewriting mechanism to allow experimenting without dealing with parsers.

### What changes did you make? (overview)

Added text rewriters, which allows to rewrite code as text but add some guarantees: comments and string literals are not affected.
It is done by _normalizing_ the source code and replacing all _literals_ with unique placeholders. Thus, using making `.gsub`-based rewriting less dangerous.

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md
