### PR TITLE
Ruby 2.5 - Rescue within blocks rewriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This would prevent from auto-transpiling a library every time when no files shou
 
 - Support Pry. ([@baygeldin][])
 
+- Add `rescue/ensure/else` within block rewriter for Ruby < 2.5. ([@fargelus][])
+
 ## 0.14.1 (2022-01-21)
 
 - Fix nested find patterns transpiling. ([@palkan][])

--- a/SUPPORTED_FEATURES.md
+++ b/SUPPORTED_FEATURES.md
@@ -58,6 +58,10 @@
 
 ## Syntax
 
+### 2.5
+
+- do/end blocks work with ensure/rescue/else ([#12906](https://bugs.ruby-lang.org/issues/12906))
+
 ### 2.6
 
 - Endless ranges (`1..` or `1...`) ([ref](https://rubyreferences.github.io/rubychanges/2.6.html#endless-range-1))

--- a/lib/ruby-next/language.rb
+++ b/lib/ruby-next/language.rb
@@ -186,6 +186,9 @@ module RubyNext
     require "ruby-next/language/rewriters/2.3/safe_navigation"
     rewriters << Rewriters::SafeNavigation
 
+    require "ruby-next/language/rewriters/2.5/rescue_within_block"
+    rewriters << Rewriters::RescueWithinBlock
+
     require "ruby-next/language/rewriters/2.7/args_forward"
     rewriters << Rewriters::ArgsForward
 

--- a/lib/ruby-next/language/rewriters/2.5/rescue_within_block.rb
+++ b/lib/ruby-next/language/rewriters/2.5/rescue_within_block.rb
@@ -22,7 +22,16 @@ module RubyNext
 
           context.track! self
 
-          replace(exception_node.loc.expression, s(:kwbegin, exception_node))
+          insert_before(exception_node.loc.expression, "begin;")
+          insert_after(exception_node.loc.expression, ";end")
+
+          new_childrens = block_node.children.map do |child|
+            next s(:kwbegin, exception_node) if child == exception_node
+
+            child
+          end
+
+          block_node.updated(:block, new_childrens)
         end
       end
     end

--- a/lib/ruby-next/language/rewriters/2.5/rescue_within_block.rb
+++ b/lib/ruby-next/language/rewriters/2.5/rescue_within_block.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RubyNext
+  module Language
+    module Rewriters
+      class RescueWithinBlock < Base
+        NAME = "rescue-within-block"
+        SYNTAX_PROBE = "lambda do
+          raise 'err'
+        rescue
+          $! # => #<RuntimeError: err>
+        end.call"
+
+        MIN_SUPPORTED_VERSION = Gem::Version.new("2.5.0")
+
+        def on_block(block_node)
+          exception_node = block_node.children.find do |node|
+            node.type == :rescue || node.type == :ensure
+          end
+
+          return unless exception_node
+
+          context.track! self
+
+          replace(exception_node.loc.expression, s(:kwbegin, exception_node))
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby-next/language/rewriters/base.rb
+++ b/lib/ruby-next/language/rewriters/base.rb
@@ -66,7 +66,7 @@ module RubyNext
         end
 
         class << self
-          # Returns true if the syntax is supported
+          # Returns true if the syntax is not supported
           # by the current Ruby (performs syntax check, not version check)
           def unsupported_syntax?
             save_verbose, $VERBOSE = $VERBOSE, nil

--- a/spec/language/rescue_within_block_spec.rb
+++ b/spec/language/rescue_within_block_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+
+using RubyNext::Language::Eval
+
+ruby_version_is "2.5" do
+  describe "rescue within do...end block" do
+    it "catches an exception in lambda" do
+      error = eval("lambda do
+                      raise 'error'
+                    rescue
+                      $!
+                    end.call", binding)
+
+      error.class.should == RuntimeError
+    end
+
+    it "raises SyntaxError with arrow block" do
+      lambda do
+        eval("-> {
+               raise 'err'
+               rescue
+                  $!
+               end
+             }.call", binding)
+      end.should raise_error SyntaxError
+    end
+
+    it "rescues when passing block to method" do
+      lambda do
+        eval("def a; yield end
+              a do
+                raise 'err'
+              rescue
+                $!
+              end",
+          binding)
+      end.should_not raise_error SyntaxError
+    end
+
+    it "raises SyntaxError with basic loop" do
+      lambda do
+        eval("while do
+                raise 'err'
+              rescue
+                $!
+              end", binding)
+      end.should raise_error SyntaxError
+    end
+
+    it "supports an old syntax" do
+      lambda do
+        eval("lambda do
+                begin
+                  raise 'err'
+                rescue
+                  $! # => #<RuntimeError: err>
+                end
+              end.call", binding)
+      end.should_not raise_error SyntaxError
+    end
+
+    it "rescues inside Procs" do
+      lambda do
+        eval("Proc.new do
+                raise 'err'
+              rescue
+                $!
+              end.call", binding)
+      end.should_not raise_error SyntaxError
+    end
+
+    it "rescues with additional ensure keyword" do
+      lambda do
+        eval("lambda do
+                raise 'err'
+              rescue
+                $!
+              ensure
+                :ensure
+              end.call", binding)
+      end.should_not raise_error SyntaxError
+    end
+
+    it "rescues when error was throwed" do
+      lambda do
+        eval("lambda do
+                throw 'err'
+              rescue
+                $!
+              end.call", binding)
+      end.should_not raise_error SyntaxError
+    end
+
+    it "accepts block without error" do
+      lambda do
+        eval("lambda do
+                :hello
+              ensure
+                :test
+              end.call", binding)
+      end.should_not raise_error SyntaxError
+    end
+
+    it "rescues when exception occurs in calling method" do
+      lambda do
+        eval("def a; raise 'err' end
+              lambda do
+                a
+              rescue
+                $!
+              end.call", binding)
+      end.should_not raise_error SyntaxError
+    end
+
+    context "iterators" do
+      it "raises SyntaxError in block-like loop" do
+        lambda do
+          eval("for i in 1..5 do
+                  raise 'err'
+                rescue
+                  $!
+                end", binding)
+        end.should raise_error SyntaxError
+      end
+
+      it "catches exception in iterators with block" do
+        lambda do
+          eval("[1, 2].each do |i|
+                  raise 'error'
+                rescue
+                  $!
+                end", binding)
+        end.should_not raise_error SyntaxError
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

<!--
  Otherwise, describe the changes: 
-->

### What is the purpose of this pull request?
PR adds rewriter for `rescue/ensure/else` inside blocks. It covers [feature-12906](https://bugs.ruby-lang.org/issues/12906).

### What changes did you make? (overview)
Add `RescueWithinBlockRewriter` which finds block with nested rescue exception and wrap `rescue` with `begin/end` keywords.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation/SUPPORTED_FEATURES.md
