### PR TITLE
Feature: An option to rewrite file inplace for ruby-next nextify #104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- An option to rewrite file inplace for ruby-next nextify. ([@dapi][])
+
 ## 0.15.3 (2022-10-16)
 
 - Fix handling nested const patterns. ([@palkan][])
@@ -364,3 +366,4 @@ p a #=> 1
 [backports]: https://github.com/marcandre/backports
 [@sl4vr]: https://github.com/sl4vr
 [@skryukov]: https://github.com/skryukov
+[@dapi]: https://github.com/dapi

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ It has the following interface:
 ```sh
 $ ruby-next nextify
 Usage: ruby-next nextify DIRECTORY_OR_FILE [options]
-    -o, --output=OUTPUT              Specify output directory or file or stdout
+    -o, --output=OUTPUT              Specify output directory or file or stdout or overwrite
         --min-version=VERSION        Specify the minimum Ruby version to support
         --single-version             Only create one version of a file (for the earliest Ruby version)
         --edge                       Enable edge (master) Ruby features
@@ -240,6 +240,22 @@ The behaviour depends on whether you transpile a single file or a directory:
 $ ruby-next nextify my_ruby.rb -o my_ruby_next.rb -V
 Ruby Next core strategy: refine
 Generated: my_ruby_next.rb
+```
+
+- When transpiling and overwrite a single file by providing `overwrite` mode as the output path no additional files or directories are created and the file is overwritten by transpiled code. For example:
+
+```sh
+$ ruby-next nextify my_ruby.rb -o overwrite -V
+Ruby Next core strategy: refine
+Overwrote: my_ruby.rb
+```
+
+Second run does not touch file because it is already transpilled:
+
+```sh
+$ ruby-next nextify my_ruby.rb -o overwrite -V
+Ruby Next core strategy: refine
+Not touched: my_ruby.rb
 ```
 
 ### `ruby-next core_ext`


### PR DESCRIPTION
The PR adds and option to rewrite file in place described here -  [#104](https://github.com/ruby-next/ruby-next/issues/104)

## Notes

1. I believe we should be sure a transpired file is not changed while transpiling. That is why I chosed to open the file in rewrite mode, block it while transpiling and overwrite it using same file descriptor.
2. I'm not sure do we really need to do something to `--single-version` option. I think we could just skip it. 

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a README.md

## There are also another solutions for this issue 

* https://github.com/ruby-next/ruby-next/pull/107
* https://github.com/ruby-next/ruby-next/pull/106
* https://github.com/ruby-next/ruby-next/pull/108