### PR TITLE
Skip specs failing on TruffleRuby

### DIFF
--- a/spec/language/pattern_matching_spec.rb
+++ b/spec/language/pattern_matching_spec.rb
@@ -512,6 +512,8 @@ ruby_version_is "2.7" do
       end
 
       it "does not support variable binding" do
+        next skip if RUBY_ENGINE == "truffleruby"
+
         -> {
           eval <<~RUBY
             case [0, 1]
@@ -642,6 +644,7 @@ ruby_version_is "2.7" do
         it "calls #deconstruct once for multiple patterns, caching the result" do
           # 2.7 doesn't cache
           next skip if RUBY_VERSION =~ /^2\.7\./
+          next skip if RUBY_ENGINE == "truffleruby"
 
           obj = Object.new
 
@@ -722,6 +725,8 @@ ruby_version_is "2.7" do
       end
 
       it "accepts a subclass of Array from #deconstruct" do
+        next skip if RUBY_ENGINE == "truffleruby"
+
         obj = Object.new
         def obj.deconstruct
           subarray = Class.new(Array).new(2)

--- a/spec/language/pattern_matching_spec.rb
+++ b/spec/language/pattern_matching_spec.rb
@@ -5,6 +5,9 @@
 # - Remove expected messages from SyntaxError
 # - Skip warnings specs
 # - Move `using refinery` inside `eval`
+#
+# Some test cases are skipped on TruffleRuby. Failing ruby/spec tests are tracked
+# in https://github.com/oracle/truffleruby/blob/master/spec/tags/language/pattern_matching_tags.txt
 
 require_relative '../spec_helper'
 

--- a/spec/language/ruby_pattern_matching_spec.rb
+++ b/spec/language/ruby_pattern_matching_spec.rb
@@ -202,11 +202,13 @@ class TestPatternMatching < Test::Unit::TestCase
       end
     end
 
+    unless RUBY_ENGINE == "truffleruby"
     assert_syntax_error(%q{
       case 0
       in a | 0
       end
     }, /illegal variable in alternative pattern/)
+    end
   end
 
   def test_var_pattern
@@ -1281,7 +1283,7 @@ END
     end
 
     # https://github.com/jruby/jruby/issues/7854
-    unless defined?(JRUBY_VERSION)
+    unless defined?(JRUBY_VERSION) || RUBY_ENGINE == "truffleruby"
     assert_block do
       case {}
       in {}
@@ -1555,7 +1557,7 @@ END
   end
 
   # Ruby 2.7 doesn't have cache
-  unless RUBY_VERSION =~ /^2\.7\./
+  unless RUBY_VERSION =~ /^2\.7\./ || RUBY_ENGINE == "truffleruby"
 
   def test_deconstruct_cache
     assert_block do

--- a/spec/language/ruby_pattern_matching_spec.rb
+++ b/spec/language/ruby_pattern_matching_spec.rb
@@ -7,6 +7,9 @@
 #  - Comment some syntax specs (see notes)
 #  - Comment out class vars or replace with gvars
 #  - Extract refeniments modules from the test class and refinements test at the end of the file
+#
+# Some test cases are skipped on TruffleRuby. Failing MRI tests are tracked
+# in https://github.com/oracle/truffleruby/blob/master/test/mri/excludes/TestPatternMatching.rb
 
 require_relative '../test_unit_to_mspec'
 

--- a/spec/language/ruby_pattern_matching_spec.rb
+++ b/spec/language/ruby_pattern_matching_spec.rb
@@ -1285,7 +1285,7 @@ END
     # https://github.com/jruby/jruby/issues/7854
     unless defined?(JRUBY_VERSION) || RUBY_ENGINE == "truffleruby"
     assert_block do
-      case {}
+      case C.new({})
       in {}
         C.keys == nil
       end


### PR DESCRIPTION
Some pattern matching specs are failing on the recent TruffleRuby release 24.0. We will investigate the issues - some of them are known. So the failing specs are temporary disabled on TruffleRuby.