### PR TITLE
Fix tests for old crubies

### DIFF
--- a/spec/language/it_param_spec.rb
+++ b/spec/language/it_param_spec.rb
@@ -4,7 +4,7 @@ require_relative '../spec_helper'
 
 using RubyNext::Language::Eval
 
-ruby_version_is "3.4"... do
+ruby_version_is "3.4"..."" do
   describe "it parameter" do
     it "provides default parameters it in a block" do
       -> { it }.call("a").should == "a"

--- a/spec/language/it_param_spec.rb
+++ b/spec/language/it_param_spec.rb
@@ -58,7 +58,7 @@ ruby_version_is "3.4"..."" do
     end
 
     it "treats an explicit `it` parameter as a fixed point" do
-      eval("1.then { |it| it.succ }", rewriters: [RubyNext::Language::Rewriters::ItParam]).should == 2
+      eval("+'x'.tap { |it| it.succ! }", rewriters: [RubyNext::Language::Rewriters::ItParam]).should == "y"
     end
   end
 end

--- a/spec/test_unit_to_mspec.rb
+++ b/spec/test_unit_to_mspec.rb
@@ -106,12 +106,13 @@ module TestUnitToMspec
       module ::Kernel
         alias_method :eval_without_transpile, :eval
 
-        def eval(src, bind = nil, *other)
+        def eval(src, bind = nil, *other, **kwargs)
           source = src.gsub(/def test_([\w_]+)/, 'it "\1" do')
           source.gsub!(/class Test(\w+).+$/, 'describe "\1" do')
           new_source = ::RubyNext::Language::Runtime.transform(
             source,
-            using: bind&.receiver == TOPLEVEL_BINDING.receiver || bind&.receiver&.is_a?(Module)
+            using: bind&.receiver == TOPLEVEL_BINDING.receiver || bind&.receiver&.is_a?(Module),
+            **kwargs
           )
           RubyNext.debug_source(new_source, "(#{caller_locations(1, 1).first})")
           eval_without_transpile new_source, bind, *other


### PR DESCRIPTION
Follow-up to https://github.com/ruby-next/ruby-next/pull/126

Before:

```shell
$ ASDF_RUBY_VERSION=3.2.8 bundle exec bin/mspec

<snip>

1) it parameter treats an explicit `it` parameter as a fixed point ERROR
NoMethodError: undefined method `receiver' for {:rewriters=>[RubyNext::Language::Rewriters::ItParam]}:Hash

77 files, 597 examples, 1388 expectations, 0 failures, 1 error, 0 tagged
```

After:

```shell
$ ASDF_RUBY_VERSION=3.2.8 bundle exec bin/mspec

<snip>

77 files, 597 examples, 1389 expectations, 0 failures, 0 errors, 0 tagged
```

